### PR TITLE
chore: format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,3 +176,16 @@ lint-markdown:
 	@markdownlint **/*.md
 
 .PHONY: lint lint-fix lint-markdown
+
+###############################################################################
+###                                Formatting                               ###
+###############################################################################
+
+format: use-main
+
+format:
+	@find . -name '*.go' -type f -not -path "*.git*" -not -path "./client/docs/statik/statik.go" -not -name '*.pb.go' -not -name '*.gw.go' | xargs go run mvdan.cc/gofumpt -w .
+	@find . -name '*.go' -type f -not -path "*.git*" -not -path "./client/docs/statik/statik.go" -not -name '*.pb.go' -not -name '*.gw.go' | xargs go run github.com/client9/misspell/cmd/misspell -w
+	@find . -name '*.go' -type f -not -path "*.git*" -not -path "./client/docs/statik/statik.go" -not -name '*.pb.go' -not -name '*.gw.go' | xargs go run golang.org/x/tools/cmd/goimports -w -local github.com/skip-mev/block-sdk
+
+.PHONY: format

--- a/Makefile
+++ b/Makefile
@@ -184,8 +184,8 @@ lint-markdown:
 format: use-main
 
 format:
-	@find . -name '*.go' -type f -not -path "*.git*" -not -path "./client/docs/statik/statik.go" -not -name '*.pb.go' -not -name '*.gw.go' | xargs go run mvdan.cc/gofumpt -w .
-	@find . -name '*.go' -type f -not -path "*.git*" -not -path "./client/docs/statik/statik.go" -not -name '*.pb.go' -not -name '*.gw.go' | xargs go run github.com/client9/misspell/cmd/misspell -w
-	@find . -name '*.go' -type f -not -path "*.git*" -not -path "./client/docs/statik/statik.go" -not -name '*.pb.go' -not -name '*.gw.go' | xargs go run golang.org/x/tools/cmd/goimports -w -local github.com/skip-mev/block-sdk
+	@find . -name '*.go' -type f -not -path "*.git*" -not -path "./client/docs/statik/statik.go" -not -name '*.pb.go' -not -name '*.pulsar.go' -not -name '*.gw.go' | xargs go run mvdan.cc/gofumpt -w .
+	@find . -name '*.go' -type f -not -path "*.git*" -not -path "./client/docs/statik/statik.go" -not -name '*.pb.go' -not -name '*.pulsar.go' -not -name '*.gw.go' | xargs go run github.com/client9/misspell/cmd/misspell -w
+	@find . -name '*.go' -type f -not -path "*.git*" -not -path "./client/docs/statik/statik.go" -not -name '*.pb.go' -not -name '*.pulsar.go' -not -name '*.gw.go' | xargs go run golang.org/x/tools/cmd/goimports -w -local github.com/skip-mev/block-sdk
 
 .PHONY: format

--- a/abci/abci.go
+++ b/abci/abci.go
@@ -6,6 +6,7 @@ import (
 	"cosmossdk.io/log"
 	abci "github.com/cometbft/cometbft/abci/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/skip-mev/block-sdk/block"
 	"github.com/skip-mev/block-sdk/block/utils"
 	"github.com/skip-mev/block-sdk/lanes/terminator"

--- a/abci/abci_test.go
+++ b/abci/abci_test.go
@@ -13,6 +13,8 @@ import (
 	cometabci "github.com/cometbft/cometbft/abci/types"
 	"github.com/cosmos/cosmos-sdk/testutil"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/suite"
+
 	"github.com/skip-mev/block-sdk/abci"
 	"github.com/skip-mev/block-sdk/block"
 	"github.com/skip-mev/block-sdk/block/base"
@@ -20,7 +22,6 @@ import (
 	"github.com/skip-mev/block-sdk/lanes/free"
 	"github.com/skip-mev/block-sdk/lanes/mev"
 	testutils "github.com/skip-mev/block-sdk/testutils"
-	"github.com/stretchr/testify/suite"
 )
 
 type ProposalsTestSuite struct {

--- a/block/base/abci.go
+++ b/block/base/abci.go
@@ -2,6 +2,7 @@ package base
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/skip-mev/block-sdk/block"
 	"github.com/skip-mev/block-sdk/block/utils"
 )

--- a/block/base/config.go
+++ b/block/base/config.go
@@ -6,6 +6,7 @@ import (
 	"cosmossdk.io/log"
 	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/skip-mev/block-sdk/block"
 )
 

--- a/block/base/handlers.go
+++ b/block/base/handlers.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/skip-mev/block-sdk/block"
 	"github.com/skip-mev/block-sdk/block/utils"
 )

--- a/block/base/lane.go
+++ b/block/base/lane.go
@@ -6,6 +6,7 @@ import (
 	"cosmossdk.io/log"
 	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/skip-mev/block-sdk/block"
 )
 

--- a/block/base/mempool.go
+++ b/block/base/mempool.go
@@ -7,6 +7,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkmempool "github.com/cosmos/cosmos-sdk/types/mempool"
+
 	"github.com/skip-mev/block-sdk/block/utils"
 )
 

--- a/block/base/types.go
+++ b/block/base/types.go
@@ -2,6 +2,7 @@ package base
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/skip-mev/block-sdk/block"
 )
 

--- a/block/mempool_test.go
+++ b/block/mempool_test.go
@@ -10,6 +10,8 @@ import (
 	storetypes "cosmossdk.io/store/types"
 	"github.com/cosmos/cosmos-sdk/testutil"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/suite"
+
 	"github.com/skip-mev/block-sdk/block"
 	"github.com/skip-mev/block-sdk/block/base"
 	defaultlane "github.com/skip-mev/block-sdk/lanes/base"
@@ -17,7 +19,6 @@ import (
 	"github.com/skip-mev/block-sdk/lanes/mev"
 	testutils "github.com/skip-mev/block-sdk/testutils"
 	buildertypes "github.com/skip-mev/block-sdk/x/builder/types"
-	"github.com/stretchr/testify/suite"
 )
 
 type BlockBusterTestSuite struct {

--- a/block/proposals.go
+++ b/block/proposals.go
@@ -7,6 +7,7 @@ import (
 
 	"cosmossdk.io/log"
 	"cosmossdk.io/math"
+
 	"github.com/skip-mev/block-sdk/block/utils"
 )
 

--- a/block/utils/mocks/lane.go
+++ b/block/utils/mocks/lane.go
@@ -246,7 +246,8 @@ func (_m *Lane) SetIgnoreList(ignoreList []block.Lane) {
 func NewLane(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *Lane {
+},
+) *Lane {
 	mock := &Lane{}
 	mock.Mock.Test(t)
 

--- a/block/utils/mocks/lane_mempool.go
+++ b/block/utils/mocks/lane_mempool.go
@@ -107,7 +107,8 @@ func (_m *LaneMempool) Select(_a0 context.Context, _a1 [][]byte) mempool.Iterato
 func NewLaneMempool(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *LaneMempool {
+},
+) *LaneMempool {
 	mock := &LaneMempool{}
 	mock.Mock.Test(t)
 

--- a/block/utils/utils_test.go
+++ b/block/utils/utils_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"cosmossdk.io/math"
+
 	"github.com/skip-mev/block-sdk/block/utils"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	cosmossdk.io/x/feegrant v0.0.0-20230724130706-5442197d6bcd
 	cosmossdk.io/x/tx v0.9.1
 	cosmossdk.io/x/upgrade v0.0.0-20230724130706-5442197d6bcd
+	github.com/client9/misspell v0.3.4
 	github.com/cometbft/cometbft v0.38.0-rc3
 	github.com/cosmos/cosmos-db v1.0.0
 	github.com/cosmos/cosmos-proto v1.0.0-beta.3
@@ -31,9 +32,11 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.16.0
 	github.com/stretchr/testify v1.8.4
+	golang.org/x/tools v0.12.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20230629202037-9506855d4529
 	google.golang.org/grpc v1.57.0
 	google.golang.org/protobuf v1.31.0
+	mvdan.cc/gofumpt v0.5.0
 )
 
 require (
@@ -305,7 +308,6 @@ require (
 	golang.org/x/sys v0.11.0 // indirect
 	golang.org/x/term v0.11.0 // indirect
 	golang.org/x/text v0.12.0 // indirect
-	golang.org/x/tools v0.12.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	google.golang.org/api v0.126.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
@@ -316,7 +318,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gotest.tools/v3 v3.5.0 // indirect
 	honnef.co/go/tools v0.4.5 // indirect
-	mvdan.cc/gofumpt v0.5.0 // indirect
 	mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed // indirect
 	mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b // indirect
 	mvdan.cc/unparam v0.0.0-20221223090309-7455f1af531d // indirect

--- a/go.sum
+++ b/go.sum
@@ -354,6 +354,7 @@ github.com/cilium/ebpf v0.7.0/go.mod h1:/oI2+1shJiTGAMgl6/RgJr36Eo1jzrRcAWbcXO2u
 github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6Dob7S7YxXgwXpfOuvO54S+tGdZdw9fuRZt25Ag=
 github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
 github.com/clbanning/x2j v0.0.0-20191024224557-825249438eec/go.mod h1:jMjuTZXRI4dUb/I5gc9Hdhagfvm9+RyrPryS/auMzxE=
+github.com/client9/misspell v0.3.4 h1:ta993UF76GwbvJcIo3Y68y/M3WxlpEHPWIGDkJYwzJI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=

--- a/lanes/base/abci_test.go
+++ b/lanes/base/abci_test.go
@@ -8,6 +8,7 @@ import (
 	"cosmossdk.io/log"
 	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/skip-mev/block-sdk/block"
 	"github.com/skip-mev/block-sdk/block/base"
 	"github.com/skip-mev/block-sdk/block/utils/mocks"

--- a/lanes/base/base_test.go
+++ b/lanes/base/base_test.go
@@ -4,8 +4,9 @@ import (
 	"math/rand"
 	"testing"
 
-	testutils "github.com/skip-mev/block-sdk/testutils"
 	"github.com/stretchr/testify/suite"
+
+	testutils "github.com/skip-mev/block-sdk/testutils"
 )
 
 type BaseTestSuite struct {

--- a/lanes/base/mempool_test.go
+++ b/lanes/base/mempool_test.go
@@ -3,6 +3,7 @@ package base_test
 import (
 	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/skip-mev/block-sdk/block/base"
 	testutils "github.com/skip-mev/block-sdk/testutils"
 )

--- a/lanes/free/lane.go
+++ b/lanes/free/lane.go
@@ -3,6 +3,7 @@ package free
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/staking/types"
+
 	"github.com/skip-mev/block-sdk/block"
 	"github.com/skip-mev/block-sdk/block/base"
 )

--- a/lanes/mev/abci.go
+++ b/lanes/mev/abci.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/skip-mev/block-sdk/block"
 	"github.com/skip-mev/block-sdk/block/base"
 	"github.com/skip-mev/block-sdk/block/utils"

--- a/lanes/mev/check_tx.go
+++ b/lanes/mev/check_tx.go
@@ -9,6 +9,7 @@ import (
 	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+
 	"github.com/skip-mev/block-sdk/x/builder/types"
 )
 

--- a/lanes/mev/factory.go
+++ b/lanes/mev/factory.go
@@ -5,6 +5,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/auth/signing"
+
 	"github.com/skip-mev/block-sdk/block/base"
 	"github.com/skip-mev/block-sdk/x/builder/types"
 )

--- a/lanes/mev/factory_test.go
+++ b/lanes/mev/factory_test.go
@@ -5,6 +5,7 @@ import (
 
 	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	testutils "github.com/skip-mev/block-sdk/testutils"
 )
 

--- a/lanes/mev/lane.go
+++ b/lanes/mev/lane.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/skip-mev/block-sdk/block"
 	"github.com/skip-mev/block-sdk/block/base"
 )

--- a/lanes/mev/mempool.go
+++ b/lanes/mev/mempool.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/skip-mev/block-sdk/block/base"
 )
 

--- a/lanes/mev/mev_test.go
+++ b/lanes/mev/mev_test.go
@@ -8,9 +8,10 @@ import (
 	"cosmossdk.io/log"
 	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/suite"
+
 	"github.com/skip-mev/block-sdk/lanes/mev"
 	testutils "github.com/skip-mev/block-sdk/testutils"
-	"github.com/stretchr/testify/suite"
 )
 
 type MEVTestSuite struct {

--- a/lanes/mev/utils.go
+++ b/lanes/mev/utils.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	buildertypes "github.com/skip-mev/block-sdk/x/builder/types"
 )
 

--- a/lanes/mev/utils_test.go
+++ b/lanes/mev/utils_test.go
@@ -4,10 +4,11 @@ import (
 	"testing"
 
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	"github.com/stretchr/testify/require"
+
 	"github.com/skip-mev/block-sdk/lanes/mev"
 	testutils "github.com/skip-mev/block-sdk/testutils"
 	buildertypes "github.com/skip-mev/block-sdk/x/builder/types"
-	"github.com/stretchr/testify/require"
 )
 
 func TestGetMsgAuctionBidFromTx_Valid(t *testing.T) {

--- a/lanes/terminator/lane.go
+++ b/lanes/terminator/lane.go
@@ -7,6 +7,7 @@ import (
 	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkmempool "github.com/cosmos/cosmos-sdk/types/mempool"
+
 	"github.com/skip-mev/block-sdk/block"
 )
 

--- a/tests/app/ante.go
+++ b/tests/app/ante.go
@@ -3,6 +3,7 @@ package app
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/auth/ante"
+
 	"github.com/skip-mev/block-sdk/block"
 	"github.com/skip-mev/block-sdk/block/utils"
 	builderante "github.com/skip-mev/block-sdk/x/builder/ante"

--- a/tests/app/config.go
+++ b/tests/app/config.go
@@ -3,8 +3,6 @@ package app
 import (
 	"time"
 
-	"google.golang.org/protobuf/types/known/durationpb"
-
 	runtimev1alpha1 "cosmossdk.io/api/cosmos/app/runtime/v1alpha1"
 	appv1alpha1 "cosmossdk.io/api/cosmos/app/v1alpha1"
 	authmodulev1 "cosmossdk.io/api/cosmos/auth/module/v1"
@@ -25,7 +23,30 @@ import (
 	txconfigv1 "cosmossdk.io/api/cosmos/tx/config/v1"
 	upgrademodulev1 "cosmossdk.io/api/cosmos/upgrade/module/v1"
 	vestingmodulev1 "cosmossdk.io/api/cosmos/vesting/module/v1"
+	"cosmossdk.io/core/appconfig"
 	"cosmossdk.io/depinject"
+	circuittypes "cosmossdk.io/x/circuit/types"
+	"cosmossdk.io/x/feegrant"
+	upgradetypes "cosmossdk.io/x/upgrade/types"
+	"github.com/cosmos/cosmos-sdk/runtime"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	vestingtypes "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
+	"github.com/cosmos/cosmos-sdk/x/authz"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	consensustypes "github.com/cosmos/cosmos-sdk/x/consensus/types"
+	crisistypes "github.com/cosmos/cosmos-sdk/x/crisis/types"
+	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
+	govclient "github.com/cosmos/cosmos-sdk/x/gov/client"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+	"github.com/cosmos/cosmos-sdk/x/group"
+	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
+	paramsclient "github.com/cosmos/cosmos-sdk/x/params/client"
+	paramstypes "github.com/cosmos/cosmos-sdk/x/params/types"
+	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"google.golang.org/protobuf/types/known/durationpb"
 
 	_ "cosmossdk.io/x/circuit"                        // import for side-effects
 	_ "cosmossdk.io/x/upgrade"                        // import for side-effects
@@ -44,33 +65,8 @@ import (
 	_ "github.com/cosmos/cosmos-sdk/x/slashing"     // import for side-effects
 	_ "github.com/cosmos/cosmos-sdk/x/staking"      // import for side-effects
 
-	_ "github.com/skip-mev/block-sdk/x/builder" // import for side-effects
-
-	"cosmossdk.io/core/appconfig"
-	circuittypes "cosmossdk.io/x/circuit/types"
-	"cosmossdk.io/x/feegrant"
-	upgradetypes "cosmossdk.io/x/upgrade/types"
-	"github.com/cosmos/cosmos-sdk/runtime"
-
-	"github.com/cosmos/cosmos-sdk/types/module"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	vestingtypes "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
-	"github.com/cosmos/cosmos-sdk/x/authz"
-	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
-	consensustypes "github.com/cosmos/cosmos-sdk/x/consensus/types"
-	crisistypes "github.com/cosmos/cosmos-sdk/x/crisis/types"
-	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
-	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
-	govclient "github.com/cosmos/cosmos-sdk/x/gov/client"
-	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
-	"github.com/cosmos/cosmos-sdk/x/group"
-	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
-	paramsclient "github.com/cosmos/cosmos-sdk/x/params/client"
-	paramstypes "github.com/cosmos/cosmos-sdk/x/params/types"
-	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
-	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
-
 	buildermodulev1 "github.com/skip-mev/block-sdk/api/sdk/builder/module/v1"
+	_ "github.com/skip-mev/block-sdk/x/builder" // import for side-effects
 	buildertypes "github.com/skip-mev/block-sdk/x/builder/types"
 )
 

--- a/tests/app/config.go
+++ b/tests/app/config.go
@@ -43,7 +43,8 @@ import (
 	_ "github.com/cosmos/cosmos-sdk/x/params"       // import for side-effects
 	_ "github.com/cosmos/cosmos-sdk/x/slashing"     // import for side-effects
 	_ "github.com/cosmos/cosmos-sdk/x/staking"      // import for side-effects
-	_ "github.com/skip-mev/block-sdk/x/builder"     // import for side-effects
+
+	_ "github.com/skip-mev/block-sdk/x/builder" // import for side-effects
 
 	"cosmossdk.io/core/appconfig"
 	circuittypes "cosmossdk.io/x/circuit/types"
@@ -68,6 +69,7 @@ import (
 	paramstypes "github.com/cosmos/cosmos-sdk/x/params/types"
 	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+
 	buildermodulev1 "github.com/skip-mev/block-sdk/api/sdk/builder/module/v1"
 	buildertypes "github.com/skip-mev/block-sdk/x/builder/types"
 )

--- a/tests/app/testappd/cmd/root.go
+++ b/tests/app/testappd/cmd/root.go
@@ -14,6 +14,7 @@ import (
 	"cosmossdk.io/depinject"
 	"cosmossdk.io/log"
 	confixcmd "cosmossdk.io/tools/confix/cmd"
+
 	"github.com/skip-mev/block-sdk/tests/app"
 
 	"github.com/cosmos/cosmos-sdk/client"

--- a/tests/app/testappd/cmd/testnet.go
+++ b/tests/app/testappd/cmd/testnet.go
@@ -15,6 +15,7 @@ import (
 
 	"cosmossdk.io/math"
 	"cosmossdk.io/math/unsafe"
+
 	"github.com/skip-mev/block-sdk/tests/app"
 
 	"github.com/cosmos/cosmos-sdk/client"

--- a/tests/app/testappd/main.go
+++ b/tests/app/testappd/main.go
@@ -5,6 +5,7 @@ import (
 
 	"cosmossdk.io/log"
 	svrcmd "github.com/cosmos/cosmos-sdk/server/cmd"
+
 	"github.com/skip-mev/block-sdk/tests/app"
 	cmd "github.com/skip-mev/block-sdk/tests/app/testappd/cmd"
 )

--- a/tests/integration/chain_setup.go
+++ b/tests/integration/chain_setup.go
@@ -16,7 +16,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
-	buildertypes "github.com/skip-mev/block-sdk/x/builder/types"
 	interchaintest "github.com/strangelove-ventures/interchaintest/v7"
 	"github.com/strangelove-ventures/interchaintest/v7/chain/cosmos"
 	"github.com/strangelove-ventures/interchaintest/v7/ibc"
@@ -26,6 +25,8 @@ import (
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+
+	buildertypes "github.com/skip-mev/block-sdk/x/builder/types"
 )
 
 // ChainBuilderFromChainSpec creates an interchaintest chain builder factory given a ChainSpec

--- a/tests/integration/pob_integration_test.go
+++ b/tests/integration/pob_integration_test.go
@@ -5,12 +5,13 @@ import (
 	"testing"
 
 	testutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
-	"github.com/skip-mev/block-sdk/tests/integration"
-	buildertypes "github.com/skip-mev/block-sdk/x/builder/types"
 	"github.com/strangelove-ventures/interchaintest/v7"
 	"github.com/strangelove-ventures/interchaintest/v7/chain/cosmos"
 	"github.com/strangelove-ventures/interchaintest/v7/ibc"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/skip-mev/block-sdk/tests/integration"
+	buildertypes "github.com/skip-mev/block-sdk/x/builder/types"
 )
 
 var (

--- a/testutils/utils.go
+++ b/testutils/utils.go
@@ -19,6 +19,7 @@ import (
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/cosmos/gogoproto/proto"
+
 	buildertypes "github.com/skip-mev/block-sdk/x/builder/types"
 )
 

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -10,5 +10,8 @@ package tools
 
 //nolint:all
 import (
+	_ "github.com/client9/misspell/cmd/misspell"
 	_ "github.com/golangci/golangci-lint/cmd/golangci-lint"
+	_ "golang.org/x/tools/cmd/goimports"
+	_ "mvdan.cc/gofumpt"
 )

--- a/x/builder/ante/ante.go
+++ b/x/builder/ante/ante.go
@@ -7,6 +7,7 @@ import (
 
 	"cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/skip-mev/block-sdk/x/builder/keeper"
 	"github.com/skip-mev/block-sdk/x/builder/types"
 )

--- a/x/builder/ante/ante_test.go
+++ b/x/builder/ante/ante_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/testutil"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/suite"
+
 	"github.com/skip-mev/block-sdk/block"
 	"github.com/skip-mev/block-sdk/block/base"
 	defaultlane "github.com/skip-mev/block-sdk/lanes/base"
@@ -19,7 +21,6 @@ import (
 	"github.com/skip-mev/block-sdk/x/builder/ante"
 	"github.com/skip-mev/block-sdk/x/builder/keeper"
 	buildertypes "github.com/skip-mev/block-sdk/x/builder/types"
-	"github.com/stretchr/testify/suite"
 )
 
 type AnteTestSuite struct {

--- a/x/builder/client/cli/query.go
+++ b/x/builder/client/cli/query.go
@@ -6,8 +6,9 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
-	"github.com/skip-mev/block-sdk/x/builder/types"
 	"github.com/spf13/cobra"
+
+	"github.com/skip-mev/block-sdk/x/builder/types"
 )
 
 // GetQueryCmd returns the cli query commands for the builder module.

--- a/x/builder/client/cli/tx.go
+++ b/x/builder/client/cli/tx.go
@@ -10,8 +10,9 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/skip-mev/block-sdk/x/builder/types"
 	"github.com/spf13/cobra"
+
+	"github.com/skip-mev/block-sdk/x/builder/types"
 )
 
 // NewTxCmd returns a root CLI command handler for all x/builder transaction

--- a/x/builder/keeper/auction.go
+++ b/x/builder/keeper/auction.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/skip-mev/block-sdk/x/builder/types"
 )
 

--- a/x/builder/keeper/auction_test.go
+++ b/x/builder/keeper/auction_test.go
@@ -6,6 +6,7 @@ import (
 
 	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	testutils "github.com/skip-mev/block-sdk/testutils"
 	"github.com/skip-mev/block-sdk/x/builder/keeper"
 	"github.com/skip-mev/block-sdk/x/builder/types"

--- a/x/builder/keeper/genesis.go
+++ b/x/builder/keeper/genesis.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/skip-mev/block-sdk/x/builder/types"
 )
 

--- a/x/builder/keeper/grpc_query.go
+++ b/x/builder/keeper/grpc_query.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/skip-mev/block-sdk/x/builder/types"
 )
 

--- a/x/builder/keeper/keeper.go
+++ b/x/builder/keeper/keeper.go
@@ -9,6 +9,7 @@ import (
 	storetypes "cosmossdk.io/store/types"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/skip-mev/block-sdk/x/builder/rewards"
 	"github.com/skip-mev/block-sdk/x/builder/types"
 )

--- a/x/builder/keeper/keeper_test.go
+++ b/x/builder/keeper/keeper_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/testutil"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/golang/mock/gomock"
+
 	testutils "github.com/skip-mev/block-sdk/testutils"
 	"github.com/skip-mev/block-sdk/x/builder/keeper"
 	"github.com/skip-mev/block-sdk/x/builder/types"

--- a/x/builder/keeper/msg_server.go
+++ b/x/builder/keeper/msg_server.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/skip-mev/block-sdk/x/builder/types"
 )
 

--- a/x/builder/keeper/msg_server_test.go
+++ b/x/builder/keeper/msg_server_test.go
@@ -7,6 +7,7 @@ import (
 	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+
 	testutils "github.com/skip-mev/block-sdk/testutils"
 	"github.com/skip-mev/block-sdk/x/builder/types"
 )

--- a/x/builder/module.go
+++ b/x/builder/module.go
@@ -18,11 +18,12 @@ import (
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	"github.com/gorilla/mux"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
+	"github.com/spf13/cobra"
+
 	modulev1 "github.com/skip-mev/block-sdk/api/sdk/builder/module/v1"
 	"github.com/skip-mev/block-sdk/x/builder/client/cli"
 	"github.com/skip-mev/block-sdk/x/builder/keeper"
 	"github.com/skip-mev/block-sdk/x/builder/types"
-	"github.com/spf13/cobra"
 )
 
 var (

--- a/x/builder/rewards/fixed_provider.go
+++ b/x/builder/rewards/fixed_provider.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/skip-mev/block-sdk/x/builder/types"
 )
 

--- a/x/builder/types/msgs_test.go
+++ b/x/builder/types/msgs_test.go
@@ -5,6 +5,7 @@ import (
 
 	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/skip-mev/block-sdk/x/builder/types"
 )
 


### PR DESCRIPTION
- add the `make format` target
- ideally `make format` should be run as a precommit hook

Note: 
- no  functionality is changed here, just the import lists.  They are now sorted so that all "local" imports  (`github.com/skip-mev/block-sdk/*`) are in their own section.