### PR TITLE
chore: module assertions for `x/auction`

### DIFF
--- a/x/auction/module.go
+++ b/x/auction/module.go
@@ -27,8 +27,12 @@ import (
 )
 
 var (
-	_ module.AppModule      = AppModule{}
-	_ module.AppModuleBasic = AppModuleBasic{}
+	_ module.AppModuleBasic = AppModule{}
+	_ module.HasGenesis     = AppModule{}
+	_ module.HasServices    = AppModule{}
+	_ module.HasInvariants  = AppModule{}
+
+	_ appmodule.AppModule = AppModule{}
 )
 
 // ConsensusVersion defines the current x/auction module consensus version.

--- a/x/auction/module.go
+++ b/x/auction/module.go
@@ -8,7 +8,6 @@ import (
 	"cosmossdk.io/core/appmodule"
 	"cosmossdk.io/depinject"
 	storetypes "cosmossdk.io/store/types"
-	abci "github.com/cometbft/cometbft/abci/types"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
@@ -131,12 +130,11 @@ func (am AppModule) RegisterInvariants(_ sdk.InvariantRegistry) {}
 
 // InitGenesis performs the module's genesis initialization for the auction
 // module. It returns no validator updates.
-func (am AppModule) InitGenesis(ctx sdk.Context, cdc codec.JSONCodec, gs json.RawMessage) []abci.ValidatorUpdate {
+func (am AppModule) InitGenesis(ctx sdk.Context, cdc codec.JSONCodec, gs json.RawMessage) {
 	var genState types.GenesisState
 	cdc.MustUnmarshalJSON(gs, &genState)
 
 	am.keeper.InitGenesis(ctx, genState)
-	return []abci.ValidatorUpdate{}
 }
 
 // ExportGenesis returns the auction module's exported genesis state as raw


### PR DESCRIPTION
Add full list of `module` static assertions for the `x/auction` module.  

Example of this usage can be seen in the cosmos sdk [here](https://github.com/cosmos/cosmos-sdk/blob/cd19bac49148e9c9689471aebad8fd474756130f/x/bank/module.go#L35C1-L43C2).  Making this assertion change, meant that the signature of `auctionmodule.InitGenesis` needed to be modified.  

This does not change any functionality.