### PR TITLE
feat: Greedy Algorithm for Lane Verification

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -7,6 +7,7 @@
   "MD033": false,
   "MD034": false,
   "MD014": false,
+  "MD013": false,
   "no-hard-tabs": false,
   "whitespace": false
 }

--- a/abci/abci.go
+++ b/abci/abci.go
@@ -108,9 +108,9 @@ func (h *ProposalHandler) PrepareProposalHandler() sdk.PrepareProposalHandler {
 // ProcessProposalHandler processes the proposal by verifying all transactions in the proposal
 // according to each lane's verification logic. Proposals are verified similar to how they are
 // constructed. After a proposal is processed, it should amount to the same proposal that was prepared.
-// Each proposal will first be broken down by the lanes that prepared each partial proposal. Then, each
-// lane will iteratively verify the transactions that it belong to it. If any lane fails to verify the
-// transactions, then the proposal is rejected.
+// The proposal is verified in a greedy fashion, respecting the ordering of lanes. A lane will
+// verify all transactions in the proposal that belong to the lane and pass any remaining transactions
+// to the next lane in the chain.
 func (h *ProposalHandler) ProcessProposalHandler() sdk.ProcessProposalHandler {
 	return func(ctx sdk.Context, req *abci.RequestProcessProposal) (resp *abci.ResponseProcessProposal, err error) {
 		if req.Height <= 1 {

--- a/abci/abci.go
+++ b/abci/abci.go
@@ -74,9 +74,8 @@ func (h *ProposalHandler) PrepareProposalHandler() sdk.PrepareProposalHandler {
 			return &abci.ResponsePrepareProposal{Txs: make([][]byte, 0)}, err
 		}
 
-		prepareLanesHandler := ChainPrepareLanes(registry)
-
 		// Fill the proposal with transactions from each lane.
+		prepareLanesHandler := ChainPrepareLanes(registry)
 		finalProposal, err := prepareLanesHandler(ctx, proposals.NewProposalWithContext(h.logger, ctx, h.txEncoder))
 		if err != nil {
 			h.logger.Error("failed to prepare proposal", "err", err)
@@ -141,9 +140,8 @@ func (h *ProposalHandler) ProcessProposalHandler() sdk.ProcessProposalHandler {
 			return &abci.ResponseProcessProposal{Status: abci.ResponseProcessProposal_REJECT}, err
 		}
 
-		processLanesHandler := ChainProcessLanes(registry)
-
 		// Verify the proposal.
+		processLanesHandler := ChainProcessLanes(registry)
 		finalProposal, err := processLanesHandler(
 			ctx,
 			proposals.NewProposalWithContext(h.logger, ctx, h.txEncoder),

--- a/abci/abci.go
+++ b/abci/abci.go
@@ -154,7 +154,7 @@ func (h *ProposalHandler) ProcessProposalHandler() sdk.ProcessProposalHandler {
 
 		h.logger.Info(
 			"processed proposal",
-			"num_txs", finalProposal.Txs,
+			"num_txs", len(finalProposal.Txs),
 			"total_tx_bytes", finalProposal.Info.BlockSize,
 			"max_tx_bytes", finalProposal.Info.MaxBlockSize,
 			"total_gas_limit", finalProposal.Info.GasLimit,

--- a/abci/abci_test.go
+++ b/abci/abci_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/skip-mev/block-sdk/abci"
 	"github.com/skip-mev/block-sdk/block"
 	"github.com/skip-mev/block-sdk/block/mocks"
-	"github.com/skip-mev/block-sdk/block/proposals"
 	testutils "github.com/skip-mev/block-sdk/testutils"
 	blocksdkmoduletypes "github.com/skip-mev/block-sdk/x/blocksdk/types"
 )
@@ -93,18 +92,7 @@ func (s *ProposalsTestSuite) TestPrepareProposal() {
 		resp, err := proposalHandler(s.ctx, &cometabci.RequestPrepareProposal{Height: 2})
 		s.Require().NoError(err)
 		s.Require().NotNil(resp)
-		s.Require().Equal(1, len(resp.Txs))
-
-		info := s.getProposalInfo(resp.Txs[0])
-		s.Require().NotNil(info)
-		s.Require().Equal(0, len(info.TxsByLane))
-
-		maxBlockSize, maxGasLimit := proposals.GetBlockLimits(s.ctx)
-		s.Require().Equal(maxBlockSize, info.MaxBlockSize)
-		s.Require().Equal(maxGasLimit, info.MaxGasLimit)
-
-		s.Require().LessOrEqual(info.BlockSize, info.MaxBlockSize)
-		s.Require().LessOrEqual(info.GasLimit, info.MaxGasLimit)
+		s.Require().Equal(0, len(resp.Txs))
 	})
 
 	s.Run("can build a proposal with a single tx from the lane", func() {
@@ -130,23 +118,11 @@ func (s *ProposalsTestSuite) TestPrepareProposal() {
 		s.Require().NoError(err)
 
 		proposal := s.getTxBytes(tx)
-		s.Require().Equal(2, len(resp.Txs))
-		s.Require().Equal(proposal, resp.Txs[1:])
-
-		info := s.getProposalInfo(resp.Txs[0])
-		s.Require().NotNil(info)
-		s.Require().Equal(1, len(info.TxsByLane))
-		s.Require().Equal(uint64(1), info.TxsByLane[defaultLane.Name()])
-
-		maxBlockSize, maxGasLimit := proposals.GetBlockLimits(s.ctx)
-		s.Require().Equal(maxBlockSize, info.MaxBlockSize)
-		s.Require().Equal(maxGasLimit, info.MaxGasLimit)
-
-		s.Require().LessOrEqual(info.BlockSize, info.MaxBlockSize)
-		s.Require().LessOrEqual(info.GasLimit, info.MaxGasLimit)
+		s.Require().Equal(1, len(resp.Txs))
+		s.Require().Equal(proposal, resp.Txs)
 	})
 
-	s.Run("can build a proposal with multiple txs from the lane", func() {
+	s.Run("can build a proposal with multiple txs from the default lane", func() {
 		// Create a random transaction that will be inserted into the default lane
 		tx1, err := testutils.CreateRandomTx(
 			s.encodingConfig.TxConfig,
@@ -182,20 +158,8 @@ func (s *ProposalsTestSuite) TestPrepareProposal() {
 		s.Require().NoError(err)
 
 		proposal := s.getTxBytes(tx2, tx1)
-		s.Require().Equal(3, len(resp.Txs))
-		s.Require().Equal(proposal, resp.Txs[1:])
-
-		info := s.getProposalInfo(resp.Txs[0])
-		s.Require().NotNil(info)
-		s.Require().Equal(1, len(info.TxsByLane))
-		s.Require().Equal(uint64(2), info.TxsByLane[defaultLane.Name()])
-
-		maxBlockSize, maxGasLimit := proposals.GetBlockLimits(s.ctx)
-		s.Require().Equal(maxBlockSize, info.MaxBlockSize)
-		s.Require().Equal(maxGasLimit, info.MaxGasLimit)
-
-		s.Require().LessOrEqual(info.BlockSize, info.MaxBlockSize)
-		s.Require().LessOrEqual(info.GasLimit, info.MaxGasLimit)
+		s.Require().Equal(2, len(resp.Txs))
+		s.Require().Equal(proposal, resp.Txs)
 	})
 
 	s.Run("can build a proposal with single tx with other that fails", func() {
@@ -234,20 +198,8 @@ func (s *ProposalsTestSuite) TestPrepareProposal() {
 		s.Require().NoError(err)
 
 		proposal := s.getTxBytes(tx1)
-		s.Require().Equal(2, len(resp.Txs))
-		s.Require().Equal(proposal, resp.Txs[1:])
-
-		info := s.getProposalInfo(resp.Txs[0])
-		s.Require().NotNil(info)
-		s.Require().Equal(1, len(info.TxsByLane))
-		s.Require().Equal(uint64(1), info.TxsByLane[defaultLane.Name()])
-
-		maxBlockSize, maxGasLimit := proposals.GetBlockLimits(s.ctx)
-		s.Require().Equal(maxBlockSize, info.MaxBlockSize)
-		s.Require().Equal(maxGasLimit, info.MaxGasLimit)
-
-		s.Require().LessOrEqual(info.BlockSize, info.MaxBlockSize)
-		s.Require().LessOrEqual(info.GasLimit, info.MaxGasLimit)
+		s.Require().Equal(1, len(resp.Txs))
+		s.Require().Equal(proposal, resp.Txs)
 	})
 
 	s.Run("can build a proposal an empty proposal with multiple lanes", func() {
@@ -259,19 +211,7 @@ func (s *ProposalsTestSuite) TestPrepareProposal() {
 		resp, err := proposalHandler(s.ctx, &cometabci.RequestPrepareProposal{Height: 2})
 		s.Require().NoError(err)
 		s.Require().NotNil(resp)
-
-		s.Require().Equal(1, len(resp.Txs))
-
-		info := s.getProposalInfo(resp.Txs[0])
-		s.Require().NotNil(info)
-		s.Require().Equal(0, len(info.TxsByLane))
-
-		maxBlockSize, maxGasLimit := proposals.GetBlockLimits(s.ctx)
-		s.Require().Equal(maxBlockSize, info.MaxBlockSize)
-		s.Require().Equal(maxGasLimit, info.MaxGasLimit)
-
-		s.Require().LessOrEqual(info.BlockSize, info.MaxBlockSize)
-		s.Require().LessOrEqual(info.GasLimit, info.MaxGasLimit)
+		s.Require().Equal(0, len(resp.Txs))
 	})
 
 	s.Run("can build a proposal with transactions from a single lane given multiple lanes", func() {
@@ -303,20 +243,8 @@ func (s *ProposalsTestSuite) TestPrepareProposal() {
 		s.Require().NotNil(resp)
 
 		proposal := s.getTxBytes(tx, bundleTxs[0])
-		s.Require().Equal(3, len(resp.Txs))
-		s.Require().Equal(proposal, resp.Txs[1:])
-
-		info := s.getProposalInfo(resp.Txs[0])
-		s.Require().NotNil(info)
-		s.Require().Equal(1, len(info.TxsByLane))
-		s.Require().Equal(uint64(2), info.TxsByLane[mevLane.Name()])
-
-		maxBlockSize, maxGasLimit := proposals.GetBlockLimits(s.ctx)
-		s.Require().Equal(maxBlockSize, info.MaxBlockSize)
-		s.Require().Equal(maxGasLimit, info.MaxGasLimit)
-
-		s.Require().LessOrEqual(info.BlockSize, info.MaxBlockSize)
-		s.Require().LessOrEqual(info.GasLimit, info.MaxGasLimit)
+		s.Require().Equal(2, len(resp.Txs))
+		s.Require().Equal(proposal, resp.Txs)
 	})
 
 	s.Run("can ignore txs that are already included in a proposal", func() {
@@ -354,20 +282,8 @@ func (s *ProposalsTestSuite) TestPrepareProposal() {
 		s.Require().NotNil(resp)
 
 		proposal := s.getTxBytes(tx, bundleTxs[0])
-		s.Require().Equal(3, len(resp.Txs))
-		s.Require().Equal(proposal, resp.Txs[1:])
-
-		info := s.getProposalInfo(resp.Txs[0])
-		s.Require().NotNil(info)
-		s.Require().Equal(1, len(info.TxsByLane))
-		s.Require().Equal(uint64(2), info.TxsByLane[mevLane.Name()])
-
-		maxBlockSize, maxGasLimit := proposals.GetBlockLimits(s.ctx)
-		s.Require().Equal(maxBlockSize, info.MaxBlockSize)
-		s.Require().Equal(maxGasLimit, info.MaxGasLimit)
-
-		s.Require().LessOrEqual(info.BlockSize, info.MaxBlockSize)
-		s.Require().LessOrEqual(info.GasLimit, info.MaxGasLimit)
+		s.Require().Equal(2, len(resp.Txs))
+		s.Require().Equal(proposal, resp.Txs)
 	})
 
 	s.Run("can build a proposal where first lane has failing tx and second lane has a valid tx", func() {
@@ -406,74 +322,8 @@ func (s *ProposalsTestSuite) TestPrepareProposal() {
 		s.Require().NotNil(resp)
 
 		proposal := s.getTxBytes(bundleTxs[0])
-		s.Require().Equal(2, len(resp.Txs))
-		s.Require().Equal(proposal, resp.Txs[1:])
-
-		info := s.getProposalInfo(resp.Txs[0])
-		s.Require().NotNil(info)
-		s.Require().Equal(1, len(info.TxsByLane))
-		s.Require().Equal(uint64(1), info.TxsByLane[defaultLane.Name()])
-
-		maxBlockSize, maxGasLimit := proposals.GetBlockLimits(s.ctx)
-		s.Require().Equal(maxBlockSize, info.MaxBlockSize)
-		s.Require().Equal(maxGasLimit, info.MaxGasLimit)
-
-		s.Require().LessOrEqual(info.BlockSize, info.MaxBlockSize)
-		s.Require().LessOrEqual(info.GasLimit, info.MaxGasLimit)
-	})
-
-	s.Run("can build a proposal where first lane cannot fit txs but second lane can", func() {
-		// Create a bid tx that includes a single bundled tx
-		tx, bundleTxs, err := testutils.CreateAuctionTx(
-			s.encodingConfig.TxConfig,
-			s.accounts[0],
-			sdk.NewCoin(s.gasTokenDenom, math.NewInt(1000000)),
-			0,
-			0,
-			s.accounts[0:1],
-			100,
-		)
-		s.Require().NoError(err)
-
-		// Set up the TOB lane with the bid tx and the bundled tx
-		mevLane := s.setUpTOBLane(math.LegacyMustNewDecFromStr("0.5"), map[sdk.Tx]bool{
-			tx:           true,
-			bundleTxs[0]: true,
-		})
-		s.Require().NoError(mevLane.Insert(sdk.Context{}, tx))
-
-		// Set up the default lane with the bid tx and the bundled tx
-		defaultLane := s.setUpStandardLane(math.LegacyMustNewDecFromStr("0.0"), map[sdk.Tx]bool{
-			// Even though this passes it should not include it in the proposal because it is in the ignore list
-			tx:           true,
-			bundleTxs[0]: true,
-		})
-		s.Require().NoError(defaultLane.Insert(sdk.Context{}, tx))
-		s.Require().NoError(defaultLane.Insert(sdk.Context{}, bundleTxs[0]))
-
-		proposalHandler := s.setUpProposalHandlers([]block.Lane{mevLane, defaultLane}).PrepareProposalHandler()
-		proposal := s.getTxBytes(tx, bundleTxs[0])
-		size := int64(len(proposal[0]) - 1)
-
-		s.setBlockParams(10000000, size)
-		resp, err := proposalHandler(s.ctx, &cometabci.RequestPrepareProposal{Height: 2})
-		s.Require().NoError(err)
-		s.Require().NotNil(resp)
-
-		s.Require().Equal(2, len(resp.Txs))
-		s.Require().Equal(proposal[1:], resp.Txs[1:])
-
-		info := s.getProposalInfo(resp.Txs[0])
-		s.Require().NotNil(info)
-		s.Require().Equal(1, len(info.TxsByLane))
-		s.Require().Equal(uint64(1), info.TxsByLane[defaultLane.Name()])
-
-		maxBlockSize, maxGasLimit := proposals.GetBlockLimits(s.ctx)
-		s.Require().Equal(maxBlockSize, info.MaxBlockSize)
-		s.Require().Equal(maxGasLimit, info.MaxGasLimit)
-
-		s.Require().LessOrEqual(info.BlockSize, info.MaxBlockSize)
-		s.Require().LessOrEqual(info.GasLimit, info.MaxGasLimit)
+		s.Require().Equal(1, len(resp.Txs))
+		s.Require().Equal(proposal, resp.Txs)
 	})
 
 	s.Run("can build a proposal with single tx from middle lane", func() {
@@ -508,20 +358,8 @@ func (s *ProposalsTestSuite) TestPrepareProposal() {
 		s.Require().NoError(err)
 		s.Require().NotNil(resp)
 
-		s.Require().Equal(2, len(resp.Txs))
-		s.Require().Equal(proposal, resp.Txs[1:])
-
-		info := s.getProposalInfo(resp.Txs[0])
-		s.Require().NotNil(info)
-		s.Require().Equal(1, len(info.TxsByLane))
-		s.Require().Equal(uint64(1), info.TxsByLane[freeLane.Name()])
-
-		maxBlockSize, maxGasLimit := proposals.GetBlockLimits(s.ctx)
-		s.Require().Equal(maxBlockSize, info.MaxBlockSize)
-		s.Require().Equal(maxGasLimit, info.MaxGasLimit)
-
-		s.Require().LessOrEqual(info.BlockSize, info.MaxBlockSize)
-		s.Require().LessOrEqual(info.GasLimit, info.MaxGasLimit)
+		s.Require().Equal(1, len(resp.Txs))
+		s.Require().Equal(proposal, resp.Txs)
 	})
 
 	s.Run("transaction from every lane", func() {
@@ -587,22 +425,8 @@ func (s *ProposalsTestSuite) TestPrepareProposal() {
 		s.Require().NoError(err)
 		s.Require().NotNil(resp)
 
-		s.Require().Equal(8, len(resp.Txs))
-		s.Require().Equal(proposal, resp.Txs[1:])
-
-		info := s.getProposalInfo(resp.Txs[0])
-		s.Require().NotNil(info)
-		s.Require().Equal(3, len(info.TxsByLane))
-		s.Require().Equal(uint64(1), info.TxsByLane[freeLane.Name()])
-		s.Require().Equal(uint64(5), info.TxsByLane[mevLane.Name()])
-		s.Require().Equal(uint64(1), info.TxsByLane[defaultLane.Name()])
-
-		maxBlockSize, maxGasLimit := proposals.GetBlockLimits(s.ctx)
-		s.Require().Equal(maxBlockSize, info.MaxBlockSize)
-		s.Require().Equal(maxGasLimit, info.MaxGasLimit)
-
-		s.Require().LessOrEqual(info.BlockSize, info.MaxBlockSize)
-		s.Require().LessOrEqual(info.GasLimit, info.MaxGasLimit)
+		s.Require().Equal(7, len(resp.Txs))
+		s.Require().Equal(proposal, resp.Txs)
 	})
 
 	s.Run("can build a proposal where first lane does not have enough gas but second lane does", func() {
@@ -653,20 +477,8 @@ func (s *ProposalsTestSuite) TestPrepareProposal() {
 		s.Require().NoError(err)
 		s.Require().NotNil(resp)
 
-		s.Require().Equal(2, len(resp.Txs))
-		s.Require().Equal(proposal[2:], resp.Txs[1:])
-
-		info := s.getProposalInfo(resp.Txs[0])
-		s.Require().NotNil(info)
-		s.Require().Equal(1, len(info.TxsByLane))
-		s.Require().Equal(uint64(1), info.TxsByLane[defaultLane.Name()])
-
-		maxBlockSize, maxGasLimit := proposals.GetBlockLimits(s.ctx)
-		s.Require().Equal(maxBlockSize, info.MaxBlockSize)
-		s.Require().Equal(maxGasLimit, info.MaxGasLimit)
-
-		s.Require().LessOrEqual(info.BlockSize, info.MaxBlockSize)
-		s.Require().LessOrEqual(info.GasLimit, info.MaxGasLimit)
+		s.Require().Equal(1, len(resp.Txs))
+		s.Require().Equal(proposal[2:], resp.Txs)
 	})
 }
 
@@ -709,7 +521,7 @@ func (s *ProposalsTestSuite) TestPrepareProposalEdgeCases() {
 		}
 
 		mempool, err := block.NewLanedMempool(
-			log.NewNopLogger(),
+			log.NewTestLogger(s.T()),
 			lanes,
 			mocks.NewMockLaneFetcher(func() (blocksdkmoduletypes.Lane, error) {
 				return blocksdkmoduletypes.Lane{}, nil
@@ -722,7 +534,7 @@ func (s *ProposalsTestSuite) TestPrepareProposalEdgeCases() {
 		defaultLane.SetIgnoreList(nil)
 
 		proposalHandler := abci.NewProposalHandler(
-			log.NewNopLogger(),
+			log.NewTestLogger(s.T()),
 			s.encodingConfig.TxConfig.TxDecoder(),
 			s.encodingConfig.TxConfig.TxEncoder(),
 			mempool,
@@ -733,20 +545,8 @@ func (s *ProposalsTestSuite) TestPrepareProposalEdgeCases() {
 		s.Require().NotNil(resp)
 
 		proposal := s.getTxBytes(tx)
-		s.Require().Equal(2, len(resp.Txs))
-		s.Require().Equal(proposal, resp.Txs[1:])
-
-		info := s.getProposalInfo(resp.Txs[0])
-		s.Require().NotNil(info)
-		s.Require().Equal(1, len(info.TxsByLane))
-		s.Require().Equal(uint64(1), info.TxsByLane[defaultLane.Name()])
-
-		maxBlockSize, maxGasLimit := proposals.GetBlockLimits(s.ctx)
-		s.Require().Equal(maxBlockSize, info.MaxBlockSize)
-		s.Require().Equal(maxGasLimit, info.MaxGasLimit)
-
-		s.Require().LessOrEqual(info.BlockSize, info.MaxBlockSize)
-		s.Require().LessOrEqual(info.GasLimit, info.MaxGasLimit)
+		s.Require().Equal(1, len(resp.Txs))
+		s.Require().Equal(proposal, resp.Txs)
 	})
 
 	s.Run("can build a proposal if second lane panics", func() {
@@ -787,7 +587,7 @@ func (s *ProposalsTestSuite) TestPrepareProposalEdgeCases() {
 		}
 
 		mempool, err := block.NewLanedMempool(
-			log.NewNopLogger(),
+			log.NewTestLogger(s.T()),
 			lanes,
 			mocks.NewMockLaneFetcher(func() (blocksdkmoduletypes.Lane, error) {
 				return blocksdkmoduletypes.Lane{}, nil
@@ -800,7 +600,7 @@ func (s *ProposalsTestSuite) TestPrepareProposalEdgeCases() {
 		defaultLane.SetIgnoreList(nil)
 
 		proposalHandler := abci.NewProposalHandler(
-			log.NewNopLogger(),
+			log.NewTestLogger(s.T()),
 			s.encodingConfig.TxConfig.TxDecoder(),
 			s.encodingConfig.TxConfig.TxEncoder(),
 			mempool,
@@ -811,20 +611,8 @@ func (s *ProposalsTestSuite) TestPrepareProposalEdgeCases() {
 		s.Require().NotNil(resp)
 
 		proposal := s.getTxBytes(tx)
-		s.Require().Equal(2, len(resp.Txs))
-		s.Require().Equal(proposal, resp.Txs[1:])
-
-		info := s.getProposalInfo(resp.Txs[0])
-		s.Require().NotNil(info)
-		s.Require().Equal(1, len(info.TxsByLane))
-		s.Require().Equal(uint64(1), info.TxsByLane[defaultLane.Name()])
-
-		maxBlockSize, maxGasLimit := proposals.GetBlockLimits(s.ctx)
-		s.Require().Equal(maxBlockSize, info.MaxBlockSize)
-		s.Require().Equal(maxGasLimit, info.MaxGasLimit)
-
-		s.Require().LessOrEqual(info.BlockSize, info.MaxBlockSize)
-		s.Require().LessOrEqual(info.GasLimit, info.MaxGasLimit)
+		s.Require().Equal(1, len(resp.Txs))
+		s.Require().Equal(proposal, resp.Txs)
 	})
 
 	s.Run("can build a proposal if multiple consecutive lanes panic", func() {
@@ -872,7 +660,7 @@ func (s *ProposalsTestSuite) TestPrepareProposalEdgeCases() {
 		}
 
 		mempool, err := block.NewLanedMempool(
-			log.NewNopLogger(),
+			log.NewTestLogger(s.T()),
 			lanes,
 			mocks.NewMockLaneFetcher(func() (blocksdkmoduletypes.Lane, error) {
 				return blocksdkmoduletypes.Lane{}, nil
@@ -887,7 +675,7 @@ func (s *ProposalsTestSuite) TestPrepareProposalEdgeCases() {
 		defaultLane.SetIgnoreList(nil)
 
 		proposalHandler := abci.NewProposalHandler(
-			log.NewNopLogger(),
+			log.NewTestLogger(s.T()),
 			s.encodingConfig.TxConfig.TxDecoder(),
 			s.encodingConfig.TxConfig.TxEncoder(),
 			mempool,
@@ -898,20 +686,8 @@ func (s *ProposalsTestSuite) TestPrepareProposalEdgeCases() {
 		s.Require().NotNil(resp)
 
 		proposal := s.getTxBytes(tx)
-		s.Require().Equal(2, len(resp.Txs))
-		s.Require().Equal(proposal, resp.Txs[1:])
-
-		info := s.getProposalInfo(resp.Txs[0])
-		s.Require().NotNil(info)
-		s.Require().Equal(1, len(info.TxsByLane))
-		s.Require().Equal(uint64(1), info.TxsByLane[defaultLane.Name()])
-
-		maxBlockSize, maxGasLimit := proposals.GetBlockLimits(s.ctx)
-		s.Require().Equal(maxBlockSize, info.MaxBlockSize)
-		s.Require().Equal(maxGasLimit, info.MaxGasLimit)
-
-		s.Require().LessOrEqual(info.BlockSize, info.MaxBlockSize)
-		s.Require().LessOrEqual(info.GasLimit, info.MaxGasLimit)
+		s.Require().Equal(1, len(resp.Txs))
+		s.Require().Equal(proposal, resp.Txs)
 	})
 
 	s.Run("can build a proposal if the last few lanes panic", func() {
@@ -959,7 +735,7 @@ func (s *ProposalsTestSuite) TestPrepareProposalEdgeCases() {
 		}
 
 		mempool, err := block.NewLanedMempool(
-			log.NewNopLogger(),
+			log.NewTestLogger(s.T()),
 			lanes,
 			mocks.NewMockLaneFetcher(func() (blocksdkmoduletypes.Lane, error) {
 				return blocksdkmoduletypes.Lane{}, nil
@@ -974,7 +750,7 @@ func (s *ProposalsTestSuite) TestPrepareProposalEdgeCases() {
 		defaultLane.SetIgnoreList(nil)
 
 		proposalHandler := abci.NewProposalHandler(
-			log.NewNopLogger(),
+			log.NewTestLogger(s.T()),
 			s.encodingConfig.TxConfig.TxDecoder(),
 			s.encodingConfig.TxConfig.TxEncoder(),
 			mempool,
@@ -985,20 +761,8 @@ func (s *ProposalsTestSuite) TestPrepareProposalEdgeCases() {
 		s.Require().NotNil(resp)
 
 		proposal := s.getTxBytes(tx)
-		s.Require().Equal(2, len(resp.Txs))
-		s.Require().Equal(proposal, resp.Txs[1:])
-
-		info := s.getProposalInfo(resp.Txs[0])
-		s.Require().NotNil(info)
-		s.Require().Equal(1, len(info.TxsByLane))
-		s.Require().Equal(uint64(1), info.TxsByLane[defaultLane.Name()])
-
-		maxBlockSize, maxGasLimit := proposals.GetBlockLimits(s.ctx)
-		s.Require().Equal(maxBlockSize, info.MaxBlockSize)
-		s.Require().Equal(maxGasLimit, info.MaxGasLimit)
-
-		s.Require().LessOrEqual(info.BlockSize, info.MaxBlockSize)
-		s.Require().LessOrEqual(info.GasLimit, info.MaxGasLimit)
+		s.Require().Equal(1, len(resp.Txs))
+		s.Require().Equal(proposal, resp.Txs)
 	})
 }
 
@@ -1009,15 +773,7 @@ func (s *ProposalsTestSuite) TestProcessProposal() {
 		defaultLane := s.setUpStandardLane(math.LegacyMustNewDecFromStr("0.0"), map[sdk.Tx]bool{})
 
 		proposalHandler := s.setUpProposalHandlers([]block.Lane{mevLane, freeLane, defaultLane}).ProcessProposalHandler()
-
-		info := s.createProposalInfoBytes(
-			0,
-			0,
-			0,
-			0,
-			nil,
-		)
-		proposal := [][]byte{info}
+		proposal := [][]byte{}
 
 		resp, err := proposalHandler(s.ctx, &cometabci.RequestProcessProposal{Txs: proposal, Height: 2})
 		s.Require().NoError(err)
@@ -1064,7 +820,7 @@ func (s *ProposalsTestSuite) TestProcessProposal() {
 
 		s.Require().Equal(2, len(txs))
 
-		proposal := s.createProposal(map[string]uint64{defaultLane.Name(): 2}, tx1, tx2)
+		proposal := s.createProposal(tx1, tx2)
 
 		proposalHandler := s.setUpProposalHandlers([]block.Lane{defaultLane}).ProcessProposalHandler()
 		resp, err := proposalHandler(s.ctx, &cometabci.RequestProcessProposal{Txs: proposal, Height: 2})
@@ -1092,7 +848,7 @@ func (s *ProposalsTestSuite) TestProcessProposal() {
 			tx: true,
 		})
 
-		proposal := s.createProposal(map[string]uint64{defaultLane.Name(): 1}, tx)
+		proposal := s.createProposal(tx)
 
 		proposalHandler := s.setUpProposalHandlers([]block.Lane{mevLane, defaultLane}).ProcessProposalHandler()
 		resp, err := proposalHandler(s.ctx, &cometabci.RequestProcessProposal{Txs: proposal, Height: 2})
@@ -1150,7 +906,7 @@ func (s *ProposalsTestSuite) TestProcessProposal() {
 			tx: true,
 		})
 
-		proposal := s.createProposal(map[string]uint64{defaultLane.Name(): 1, mevLane.Name(): 2, freeLane.Name(): 1}, bidTx, bundleTxs[0], freeTx, tx)
+		proposal := s.createProposal(bidTx, bundleTxs[0], freeTx, tx)
 
 		proposalHandler := s.setUpProposalHandlers([]block.Lane{mevLane, freeLane, defaultLane}).ProcessProposalHandler()
 		resp, err := proposalHandler(s.ctx, &cometabci.RequestProcessProposal{Txs: proposal, Height: 2})
@@ -1159,89 +915,13 @@ func (s *ProposalsTestSuite) TestProcessProposal() {
 		s.Require().Equal(&cometabci.ResponseProcessProposal{Status: cometabci.ResponseProcessProposal_ACCEPT}, resp)
 	})
 
-	s.Run("rejects a proposal with mismatching block size", func() {
-		tx, err := testutils.CreateRandomTx(
-			s.encodingConfig.TxConfig,
-			s.accounts[0],
-			0,
-			0,
-			0,
-			100,
-			sdk.NewCoin(s.gasTokenDenom, math.NewInt(1000000)),
-		)
-		s.Require().NoError(err)
-
-		mevLane := s.setUpTOBLane(math.LegacyMustNewDecFromStr("0.25"), map[sdk.Tx]bool{})
-		defaultLane := s.setUpStandardLane(math.LegacyMustNewDecFromStr("0.0"), map[sdk.Tx]bool{
-			tx: true,
-		})
-
-		proposal := s.createProposal(map[string]uint64{defaultLane.Name(): 1, mevLane.Name(): 0}, tx)
-
-		// modify the block size to be 1
-		info := s.getProposalInfo(proposal[0])
-		info.BlockSize--
-		infoBz, err := info.Marshal()
-		s.Require().NoError(err)
-		proposal[0] = infoBz
-
-		proposalHandler := s.setUpProposalHandlers([]block.Lane{mevLane, defaultLane}).ProcessProposalHandler()
-		resp, err := proposalHandler(s.ctx, &cometabci.RequestProcessProposal{Txs: proposal, Height: 2})
-		s.Require().Error(err)
-		s.Require().Equal(&cometabci.ResponseProcessProposal{Status: cometabci.ResponseProcessProposal_REJECT}, resp)
-	})
-
-	s.Run("rejects a proposal with mismatching gas limit", func() {
-		tx, err := testutils.CreateRandomTx(
-			s.encodingConfig.TxConfig,
-			s.accounts[0],
-			0,
-			0,
-			0,
-			100,
-			sdk.NewCoin(s.gasTokenDenom, math.NewInt(1000000)),
-		)
-		s.Require().NoError(err)
-
-		mevLane := s.setUpTOBLane(math.LegacyMustNewDecFromStr("0.25"), map[sdk.Tx]bool{})
-		defaultLane := s.setUpStandardLane(math.LegacyMustNewDecFromStr("0.0"), map[sdk.Tx]bool{
-			tx: true,
-		})
-
-		proposal := s.createProposal(map[string]uint64{defaultLane.Name(): 1, mevLane.Name(): 0}, tx)
-
-		// modify the block size to be 1
-		info := s.getProposalInfo(proposal[0])
-		info.GasLimit--
-		infoBz, err := info.Marshal()
-		s.Require().NoError(err)
-		proposal[0] = infoBz
-
-		proposalHandler := s.setUpProposalHandlers([]block.Lane{mevLane, defaultLane}).ProcessProposalHandler()
-		resp, err := proposalHandler(s.ctx, &cometabci.RequestProcessProposal{Txs: proposal, Height: 2})
-		s.Require().Error(err)
-		s.Require().Equal(&cometabci.ResponseProcessProposal{Status: cometabci.ResponseProcessProposal_REJECT}, resp)
-	})
-
 	s.Run("rejects a proposal with bad txs", func() {
 		mevLane := s.setUpTOBLane(math.LegacyMustNewDecFromStr("0.25"), map[sdk.Tx]bool{})
 		freeLane := s.setUpFreeLane(math.LegacyMustNewDecFromStr("0.25"), map[sdk.Tx]bool{})
 		defaultLane := s.setUpStandardLane(math.LegacyMustNewDecFromStr("0.0"), map[sdk.Tx]bool{})
 
 		proposalHandler := s.setUpProposalHandlers([]block.Lane{mevLane, freeLane, defaultLane}).ProcessProposalHandler()
-
-		info := s.createProposalInfoBytes(
-			0,
-			0,
-			0,
-			0,
-			map[string]uint64{
-				mevLane.Name():     0,
-				freeLane.Name():    0,
-				defaultLane.Name(): 1,
-			},
-		)
-		proposal := [][]byte{info, {0x01, 0x02, 0x03}}
+		proposal := [][]byte{{0x01, 0x02, 0x03}}
 
 		resp, err := proposalHandler(s.ctx, &cometabci.RequestProcessProposal{Txs: proposal, Height: 2})
 		s.Require().Error(err)
@@ -1263,17 +943,7 @@ func (s *ProposalsTestSuite) TestProcessProposal() {
 		s.Require().NoError(err)
 
 		proposalHandler := s.setUpProposalHandlers([]block.Lane{mevLane, panicLane}).ProcessProposalHandler()
-
-		info := s.createProposalInfoBytes(
-			0,
-			0,
-			0,
-			0,
-			map[string]uint64{
-				panicLane.Name(): 1,
-			},
-		)
-		proposal := [][]byte{info, txbz}
+		proposal := [][]byte{txbz}
 
 		resp, err := proposalHandler(s.ctx, &cometabci.RequestProcessProposal{Txs: proposal, Height: 2})
 		s.Require().Error(err)
@@ -1311,7 +981,7 @@ func (s *ProposalsTestSuite) TestProcessProposal() {
 		defaultLane := s.setUpStandardLane(math.LegacyMustNewDecFromStr("0.0"), map[sdk.Tx]bool{tx2: true})
 		s.Require().NoError(defaultLane.Insert(sdk.Context{}, tx))
 
-		proposal := s.createProposal(map[string]uint64{defaultLane.Name(): 1, mevLane.Name(): 1}, tx2, tx)
+		proposal := s.createProposal(tx2, tx)
 
 		proposalHandler := s.setUpProposalHandlers([]block.Lane{mevLane, defaultLane}).ProcessProposalHandler()
 		resp, err := proposalHandler(s.ctx, &cometabci.RequestProcessProposal{Txs: proposal, Height: 2})
@@ -1366,7 +1036,7 @@ func (s *ProposalsTestSuite) TestProcessProposal() {
 			bundle[1]: true,
 		})
 
-		proposal := s.createProposal(map[string]uint64{defaultLane.Name(): 2, mevLane.Name(): 3}, bidTx, bundle[0], bundle[1], normalTx, normalTx2)
+		proposal := s.createProposal(bidTx, bundle[0], bundle[1], normalTx, normalTx2)
 
 		proposalHandler := s.setUpProposalHandlers([]block.Lane{mevLane, defaultLane}).ProcessProposalHandler()
 		resp, err := proposalHandler(s.ctx, &cometabci.RequestProcessProposal{Txs: proposal, Height: 2})
@@ -1416,7 +1086,7 @@ func (s *ProposalsTestSuite) TestProcessProposal() {
 		// Set up the TOB lane
 		mevLane := s.setUpTOBLane(math.LegacyMustNewDecFromStr("0.1"), nil)
 
-		proposal := s.createProposal(map[string]uint64{defaultLane.Name(): 2, mevLane.Name(): 1}, bidTx, normalTx, normalTx2)
+		proposal := s.createProposal(bidTx, normalTx, normalTx2)
 
 		proposalHandler := s.setUpProposalHandlers([]block.Lane{mevLane, defaultLane}).ProcessProposalHandler()
 		resp, err := proposalHandler(s.ctx, &cometabci.RequestProcessProposal{Txs: proposal, Height: 2})
@@ -1473,7 +1143,7 @@ func (s *ProposalsTestSuite) TestProcessProposal() {
 			bidTx: true,
 		})
 
-		proposal := s.createProposal(map[string]uint64{defaultLane.Name(): 2, mevLane.Name(): 1}, bidTx, normalTx, normalTx2)
+		proposal := s.createProposal(bidTx, normalTx, normalTx2)
 
 		proposalHandler := s.setUpProposalHandlers([]block.Lane{mevLane, defaultLane}).ProcessProposalHandler()
 		resp, err := proposalHandler(s.ctx, &cometabci.RequestProcessProposal{Txs: proposal, Height: 2})
@@ -1573,29 +1243,21 @@ func (s *ProposalsTestSuite) TestPrepareProcessParity() {
 	s.Require().NoError(err)
 	s.Require().NotNil(resp)
 
-	info := s.getProposalInfo(resp.Txs[0])
-	s.Require().NotNil(info)
-	s.Require().Equal(2, len(info.TxsByLane))
-	s.Require().Equal(numTxsPerLane, info.TxsByLane[defaultLane.Name()])
-	s.Require().Equal(numTxsPerLane, info.TxsByLane[freelane.Name()])
-	s.Require().Equal(numTxsPerLane*2, uint64(len(resp.Txs)-1))
-
 	// Ensure the transactions are in the correct order for the free lane
 	for i := 0; i < int(numTxsPerLane); i++ {
 		bz, err := s.encodingConfig.TxConfig.TxEncoder()(freeRetrievedTxs[i])
 		s.Require().NoError(err)
-		s.Require().Equal(bz, resp.Txs[i+1])
+		s.Require().Equal(bz, resp.Txs[i])
 	}
 
 	// Ensure the transactions are in the correct order for the default lane
 	for i := 0; i < int(numTxsPerLane); i++ {
 		bz, err := s.encodingConfig.TxConfig.TxEncoder()(retrievedTxs[i])
 		s.Require().NoError(err)
-		s.Require().Equal(bz, resp.Txs[i+1+int(numTxsPerLane)])
+		s.Require().Equal(bz, resp.Txs[i+int(numTxsPerLane)])
 	}
 
 	proposal := s.createProposal(
-		map[string]uint64{defaultLane.Name(): numTxsPerLane, freelane.Name(): numTxsPerLane},
 		append(freeRetrievedTxs, retrievedTxs...)...,
 	)
 
@@ -1692,7 +1354,6 @@ func (s *ProposalsTestSuite) TestIterateMempoolAndProcessProposalParity() {
 	s.Require().Equal(numTxsPerLane, uint64(len(freeRetrievedTxs)))
 
 	proposal := s.createProposal(
-		map[string]uint64{defaultLane.Name(): numTxsPerLane, freelane.Name(): numTxsPerLane},
 		append(freeRetrievedTxs, retrievedTxs...)...,
 	)
 
@@ -1701,208 +1362,4 @@ func (s *ProposalsTestSuite) TestIterateMempoolAndProcessProposalParity() {
 	resp, err := proposalHandler(s.ctx, &cometabci.RequestProcessProposal{Txs: proposal, Height: 2})
 	s.Require().NotNil(resp)
 	s.Require().NoError(err)
-}
-
-func (s *ProposalsTestSuite) TestValidateBasic() {
-	// Set up the default lane with no transactions
-	mevlane := s.setUpTOBLane(math.LegacyMustNewDecFromStr("0.25"), nil)
-	freelane := s.setUpFreeLane(math.LegacyMustNewDecFromStr("0.25"), nil)
-	defaultLane := s.setUpStandardLane(math.LegacyMustNewDecFromStr("0.0"), nil)
-
-	proposalHandlers := s.setUpProposalHandlers([]block.Lane{
-		mevlane,
-		freelane,
-		defaultLane,
-	})
-
-	s.Run("can validate an empty proposal", func() {
-		info := s.createProposalInfoBytes(0, 0, 0, 0, nil)
-		proposal := [][]byte{info}
-
-		_, partialProposals, err := proposalHandlers.ExtractLanes(s.ctx, proposal)
-		s.Require().NoError(err)
-		s.Require().Equal(3, len(partialProposals))
-
-		for _, partialProposal := range partialProposals {
-			s.Require().Equal(0, len(partialProposal))
-		}
-	})
-
-	s.Run("should invalidate proposal with mismatch in transactions and proposal info", func() {
-		info := s.createProposalInfoBytes(0, 0, 0, 0, nil)
-		proposal := [][]byte{info, {0x01, 0x02, 0x03}}
-
-		_, _, err := proposalHandlers.ExtractLanes(s.ctx, proposal)
-		s.Require().Error(err)
-	})
-
-	s.Run("should invalidate proposal without info", func() {
-		proposal := [][]byte{{0x01, 0x02, 0x03}}
-
-		_, _, err := proposalHandlers.ExtractLanes(s.ctx, proposal)
-		s.Require().Error(err)
-	})
-
-	s.Run("should invalidate completely empty proposal", func() {
-		proposal := [][]byte{}
-
-		_, _, err := proposalHandlers.ExtractLanes(s.ctx, proposal)
-		s.Require().Error(err)
-	})
-
-	s.Run("should invalidate proposal with mismatch txs count with proposal info", func() {
-		info := s.createProposalInfoBytes(0, 0, 0, 0, nil)
-		proposal := [][]byte{info, {0x01, 0x02, 0x03}, {0x01, 0x02, 0x03}}
-
-		_, _, err := proposalHandlers.ExtractLanes(s.ctx, proposal)
-		s.Require().Error(err)
-	})
-
-	s.Run("can validate a proposal with a single tx", func() {
-		tx, err := testutils.CreateRandomTx(
-			s.encodingConfig.TxConfig,
-			s.accounts[0],
-			0,
-			0,
-			0,
-			1,
-		)
-		s.Require().NoError(err)
-		proposal := s.getTxBytes(tx)
-
-		size, limit := s.getTxInfos(tx)
-		maxSize, maxLimit := proposals.GetBlockLimits(s.ctx)
-		info := s.createProposalInfoBytes(
-			maxLimit,
-			limit,
-			maxSize,
-			size,
-			map[string]uint64{
-				defaultLane.Name(): 1,
-			},
-		)
-
-		proposal = append([][]byte{info}, proposal...)
-
-		_, partialProposals, err := proposalHandlers.ExtractLanes(s.ctx, proposal)
-		s.Require().NoError(err)
-
-		s.Require().Equal(3, len(partialProposals))
-		s.Require().Equal(0, len(partialProposals[0]))
-		s.Require().Equal(0, len(partialProposals[1]))
-		s.Require().Equal(1, len(partialProposals[2]))
-		s.Require().Equal(proposal[1], partialProposals[2][0])
-	})
-
-	s.Run("can validate a proposal with multiple txs from single lane", func() {
-		tx, err := testutils.CreateRandomTx(
-			s.encodingConfig.TxConfig,
-			s.accounts[0],
-			0,
-			0,
-			0,
-			1,
-		)
-		s.Require().NoError(err)
-
-		tx2, err := testutils.CreateRandomTx(
-			s.encodingConfig.TxConfig,
-			s.accounts[1],
-			0,
-			0,
-			0,
-			1,
-		)
-		s.Require().NoError(err)
-
-		proposal := s.getTxBytes(tx, tx2)
-
-		size, limit := s.getTxInfos(tx, tx2)
-		maxSize, maxLimit := proposals.GetBlockLimits(s.ctx)
-		info := s.createProposalInfoBytes(
-			maxLimit,
-			limit,
-			maxSize,
-			size,
-			map[string]uint64{
-				defaultLane.Name(): 2,
-			},
-		)
-
-		proposal = append([][]byte{info}, proposal...)
-
-		_, partialProposals, err := proposalHandlers.ExtractLanes(s.ctx, proposal)
-		s.Require().NoError(err)
-
-		s.Require().Equal(3, len(partialProposals))
-		s.Require().Equal(0, len(partialProposals[0]))
-		s.Require().Equal(0, len(partialProposals[1]))
-		s.Require().Equal(2, len(partialProposals[2]))
-		s.Require().Equal(proposal[1], partialProposals[2][0])
-		s.Require().Equal(proposal[2], partialProposals[2][1])
-	})
-
-	s.Run("can validate a proposal with 1 tx from each lane", func() {
-		tx, err := testutils.CreateRandomTx(
-			s.encodingConfig.TxConfig,
-			s.accounts[0],
-			0,
-			0,
-			0,
-			1,
-		)
-		s.Require().NoError(err)
-
-		tx2, err := testutils.CreateRandomTx(
-			s.encodingConfig.TxConfig,
-			s.accounts[1],
-			0,
-			0,
-			0,
-			1,
-		)
-		s.Require().NoError(err)
-
-		tx3, err := testutils.CreateRandomTx(
-			s.encodingConfig.TxConfig,
-			s.accounts[2],
-			0,
-			0,
-			0,
-			1,
-		)
-		s.Require().NoError(err)
-
-		proposal := s.getTxBytes(tx, tx2, tx3)
-
-		size, limit := s.getTxInfos(tx, tx2, tx3)
-		maxSize, maxLimit := proposals.GetBlockLimits(s.ctx)
-
-		info := s.createProposalInfoBytes(
-			maxLimit,
-			limit,
-			maxSize,
-			size,
-			map[string]uint64{
-				defaultLane.Name(): 1,
-				mevlane.Name():     1,
-				freelane.Name():    1,
-			},
-		)
-
-		proposal = append([][]byte{info}, proposal...)
-
-		_, partialProposals, err := proposalHandlers.ExtractLanes(s.ctx, proposal)
-		s.Require().NoError(err)
-
-		s.Require().Equal(3, len(partialProposals))
-		s.Require().Equal(1, len(partialProposals[0]))
-		s.Require().Equal(proposal[1], partialProposals[0][0])
-
-		s.Require().Equal(1, len(partialProposals[1]))
-		s.Require().Equal(proposal[2], partialProposals[1][0])
-
-		s.Require().Equal(1, len(partialProposals[2]))
-		s.Require().Equal(proposal[3], partialProposals[2][0])
-	})
 }

--- a/abci/utils.go
+++ b/abci/utils.go
@@ -67,7 +67,10 @@ func ChainPrepareLanes(chain []block.Lane) block.PrepareLanesHandler {
 // ChainProcessLanes chains together the proposal verification logic from each lane
 // into a single function. The first lane in the chain is the first lane to be verified and
 // the last lane in the chain is the last lane to be verified. Each lane will validate
-// the transactions that it selected in the prepare phase.
+// the transactions that belong to the lane and pass any remaining transactions to the next
+// lane in the chain. If any of the lanes fail to verify the transactions, the proposal will
+// be rejected. If there are any remaining transactions after all lanes have been processed,
+// the proposal will be rejected.
 func ChainProcessLanes(chain []block.Lane) block.ProcessLanesHandler {
 	if len(chain) == 0 {
 		return nil

--- a/abci/utils_test.go
+++ b/abci/utils_test.go
@@ -17,9 +17,6 @@ import (
 	signeradaptors "github.com/skip-mev/block-sdk/adapters/signer_extraction_adapter"
 	"github.com/skip-mev/block-sdk/block"
 	"github.com/skip-mev/block-sdk/block/base"
-	"github.com/skip-mev/block-sdk/block/proposals"
-	"github.com/skip-mev/block-sdk/block/proposals/types"
-	"github.com/skip-mev/block-sdk/block/utils"
 	defaultlane "github.com/skip-mev/block-sdk/lanes/base"
 	"github.com/skip-mev/block-sdk/lanes/free"
 	"github.com/skip-mev/block-sdk/lanes/mev"
@@ -60,7 +57,7 @@ func (s *ProposalsTestSuite) setUpAnteHandler(expectedExecution map[sdk.Tx]bool)
 
 func (s *ProposalsTestSuite) setUpStandardLane(maxBlockSpace math.LegacyDec, expectedExecution map[sdk.Tx]bool) *defaultlane.DefaultLane {
 	cfg := base.LaneConfig{
-		Logger:          log.NewNopLogger(),
+		Logger:          log.NewTestLogger(s.T()),
 		TxEncoder:       s.encodingConfig.TxConfig.TxEncoder(),
 		TxDecoder:       s.encodingConfig.TxConfig.TxDecoder(),
 		AnteHandler:     s.setUpAnteHandler(expectedExecution),
@@ -74,7 +71,7 @@ func (s *ProposalsTestSuite) setUpStandardLane(maxBlockSpace math.LegacyDec, exp
 
 func (s *ProposalsTestSuite) setUpTOBLane(maxBlockSpace math.LegacyDec, expectedExecution map[sdk.Tx]bool) *mev.MEVLane {
 	cfg := base.LaneConfig{
-		Logger:          log.NewNopLogger(),
+		Logger:          log.NewTestLogger(s.T()),
 		TxEncoder:       s.encodingConfig.TxConfig.TxEncoder(),
 		TxDecoder:       s.encodingConfig.TxConfig.TxDecoder(),
 		AnteHandler:     s.setUpAnteHandler(expectedExecution),
@@ -87,7 +84,7 @@ func (s *ProposalsTestSuite) setUpTOBLane(maxBlockSpace math.LegacyDec, expected
 
 func (s *ProposalsTestSuite) setUpFreeLane(maxBlockSpace math.LegacyDec, expectedExecution map[sdk.Tx]bool) *free.FreeLane {
 	cfg := base.LaneConfig{
-		Logger:          log.NewNopLogger(),
+		Logger:          log.NewTestLogger(s.T()),
 		TxEncoder:       s.encodingConfig.TxConfig.TxEncoder(),
 		TxDecoder:       s.encodingConfig.TxConfig.TxDecoder(),
 		AnteHandler:     s.setUpAnteHandler(expectedExecution),
@@ -100,7 +97,7 @@ func (s *ProposalsTestSuite) setUpFreeLane(maxBlockSpace math.LegacyDec, expecte
 
 func (s *ProposalsTestSuite) setUpPanicLane(name string, maxBlockSpace math.LegacyDec) *base.BaseLane {
 	cfg := base.LaneConfig{
-		Logger:          log.NewNopLogger(),
+		Logger:          log.NewTestLogger(s.T()),
 		TxEncoder:       s.encodingConfig.TxConfig.TxEncoder(),
 		TxDecoder:       s.encodingConfig.TxConfig.TxDecoder(),
 		MaxBlockSpace:   maxBlockSpace,
@@ -139,65 +136,22 @@ func (s *ProposalsTestSuite) setUpProposalHandlers(lanes []block.Lane) *abci.Pro
 		})
 
 	mempool, err := block.NewLanedMempool(
-		log.NewNopLogger(),
+		log.NewTestLogger(s.T()),
 		lanes,
 		laneFetcher,
 	)
 	s.Require().NoError(err)
 
 	return abci.NewProposalHandler(
-		log.NewNopLogger(),
+		log.NewTestLogger(s.T()),
 		s.encodingConfig.TxConfig.TxDecoder(),
 		s.encodingConfig.TxConfig.TxEncoder(),
 		mempool,
 	)
 }
 
-func (s *ProposalsTestSuite) createProposal(distribution map[string]uint64, txs ...sdk.Tx) [][]byte {
-	maxSize, maxGasLimit := proposals.GetBlockLimits(s.ctx)
-	size, limit := s.getTxInfos(txs...)
-
-	info := s.createProposalInfoBytes(
-		maxGasLimit,
-		limit,
-		maxSize,
-		size,
-		distribution,
-	)
-
-	proposal := s.getTxBytes(txs...)
-	return append([][]byte{info}, proposal...)
-}
-
-func (s *ProposalsTestSuite) getProposalInfo(bz []byte) types.ProposalInfo {
-	var info types.ProposalInfo
-	s.Require().NoError(info.Unmarshal(bz))
-	return info
-}
-
-func (s *ProposalsTestSuite) createProposalInfo(
-	maxGasLimit, gasLimit uint64,
-	maxBlockSize, blockSize int64,
-	txsByLane map[string]uint64,
-) types.ProposalInfo {
-	return types.ProposalInfo{
-		MaxGasLimit:  maxGasLimit,
-		GasLimit:     gasLimit,
-		MaxBlockSize: maxBlockSize,
-		BlockSize:    blockSize,
-		TxsByLane:    txsByLane,
-	}
-}
-
-func (s *ProposalsTestSuite) createProposalInfoBytes(
-	maxGasLimit, gasLimit uint64,
-	maxBlockSize, blockSize int64,
-	txsByLane map[string]uint64,
-) []byte {
-	info := s.createProposalInfo(maxGasLimit, gasLimit, maxBlockSize, blockSize, txsByLane)
-	bz, err := info.Marshal()
-	s.Require().NoError(err)
-	return bz
+func (s *ProposalsTestSuite) createProposal(txs ...sdk.Tx) [][]byte {
+	return s.getTxBytes(txs...)
 }
 
 func (s *ProposalsTestSuite) getTxBytes(txs ...sdk.Tx) [][]byte {
@@ -209,21 +163,6 @@ func (s *ProposalsTestSuite) getTxBytes(txs ...sdk.Tx) [][]byte {
 		txBytes[i] = bz
 	}
 	return txBytes
-}
-
-func (s *ProposalsTestSuite) getTxInfos(txs ...sdk.Tx) (int64, uint64) {
-	totalSize := int64(0)
-	totalGasLimit := uint64(0)
-
-	for _, tx := range txs {
-		info, err := utils.GetTxInfo(s.encodingConfig.TxConfig.TxEncoder(), tx)
-		s.Require().NoError(err)
-
-		totalSize += info.Size
-		totalGasLimit += info.GasLimit
-	}
-
-	return totalSize, totalGasLimit
 }
 
 func (s *ProposalsTestSuite) setBlockParams(maxGasLimit, maxBlockSize int64) {

--- a/abci/utils_test.go
+++ b/abci/utils_test.go
@@ -55,9 +55,32 @@ func (s *ProposalsTestSuite) setUpAnteHandler(expectedExecution map[sdk.Tx]bool)
 	return anteHandler
 }
 
+func (s *ProposalsTestSuite) setUpCustomMatchHandlerLane(maxBlockSpace math.LegacyDec, expectedExecution map[sdk.Tx]bool, mh base.MatchHandler, name string) block.Lane {
+	cfg := base.LaneConfig{
+		Logger:          log.NewNopLogger(),
+		TxEncoder:       s.encodingConfig.TxConfig.TxEncoder(),
+		TxDecoder:       s.encodingConfig.TxConfig.TxDecoder(),
+		AnteHandler:     s.setUpAnteHandler(expectedExecution),
+		MaxBlockSpace:   maxBlockSpace,
+		SignerExtractor: signeradaptors.NewDefaultAdapter(),
+	}
+
+	lane := base.NewBaseLane(
+		cfg,
+		name,
+		base.NewMempool[string](base.DefaultTxPriority(), cfg.TxEncoder, cfg.SignerExtractor, 0),
+		mh,
+	)
+
+	lane.SetPrepareLaneHandler(lane.DefaultPrepareLaneHandler())
+	lane.SetProcessLaneHandler(lane.DefaultProcessLaneHandler())
+
+	return lane
+}
+
 func (s *ProposalsTestSuite) setUpStandardLane(maxBlockSpace math.LegacyDec, expectedExecution map[sdk.Tx]bool) *defaultlane.DefaultLane {
 	cfg := base.LaneConfig{
-		Logger:          log.NewTestLogger(s.T()),
+		Logger:          log.NewNopLogger(),
 		TxEncoder:       s.encodingConfig.TxConfig.TxEncoder(),
 		TxDecoder:       s.encodingConfig.TxConfig.TxDecoder(),
 		AnteHandler:     s.setUpAnteHandler(expectedExecution),
@@ -71,7 +94,7 @@ func (s *ProposalsTestSuite) setUpStandardLane(maxBlockSpace math.LegacyDec, exp
 
 func (s *ProposalsTestSuite) setUpTOBLane(maxBlockSpace math.LegacyDec, expectedExecution map[sdk.Tx]bool) *mev.MEVLane {
 	cfg := base.LaneConfig{
-		Logger:          log.NewTestLogger(s.T()),
+		Logger:          log.NewNopLogger(),
 		TxEncoder:       s.encodingConfig.TxConfig.TxEncoder(),
 		TxDecoder:       s.encodingConfig.TxConfig.TxDecoder(),
 		AnteHandler:     s.setUpAnteHandler(expectedExecution),
@@ -84,7 +107,7 @@ func (s *ProposalsTestSuite) setUpTOBLane(maxBlockSpace math.LegacyDec, expected
 
 func (s *ProposalsTestSuite) setUpFreeLane(maxBlockSpace math.LegacyDec, expectedExecution map[sdk.Tx]bool) *free.FreeLane {
 	cfg := base.LaneConfig{
-		Logger:          log.NewTestLogger(s.T()),
+		Logger:          log.NewNopLogger(),
 		TxEncoder:       s.encodingConfig.TxConfig.TxEncoder(),
 		TxDecoder:       s.encodingConfig.TxConfig.TxDecoder(),
 		AnteHandler:     s.setUpAnteHandler(expectedExecution),
@@ -97,7 +120,7 @@ func (s *ProposalsTestSuite) setUpFreeLane(maxBlockSpace math.LegacyDec, expecte
 
 func (s *ProposalsTestSuite) setUpPanicLane(name string, maxBlockSpace math.LegacyDec) *base.BaseLane {
 	cfg := base.LaneConfig{
-		Logger:          log.NewTestLogger(s.T()),
+		Logger:          log.NewNopLogger(),
 		TxEncoder:       s.encodingConfig.TxConfig.TxEncoder(),
 		TxDecoder:       s.encodingConfig.TxConfig.TxDecoder(),
 		MaxBlockSpace:   maxBlockSpace,
@@ -136,14 +159,14 @@ func (s *ProposalsTestSuite) setUpProposalHandlers(lanes []block.Lane) *abci.Pro
 		})
 
 	mempool, err := block.NewLanedMempool(
-		log.NewTestLogger(s.T()),
+		log.NewNopLogger(),
 		lanes,
 		laneFetcher,
 	)
 	s.Require().NoError(err)
 
 	return abci.NewProposalHandler(
-		log.NewTestLogger(s.T()),
+		log.NewNopLogger(),
 		s.encodingConfig.TxConfig.TxDecoder(),
 		s.encodingConfig.TxConfig.TxEncoder(),
 		mempool,

--- a/block/base/abci.go
+++ b/block/base/abci.go
@@ -97,7 +97,6 @@ func (l *BaseLane) ProcessLane(
 			"failed to process lane",
 			"lane", l.Name(),
 			"err", err,
-			"num_txs_to_verify", len(txs),
 		)
 
 		return proposal, err
@@ -108,8 +107,8 @@ func (l *BaseLane) ProcessLane(
 		l.Logger().Error(
 			"failed to update proposal",
 			"lane", l.Name(),
+			"num_txs_verified", len(txsFromLane),
 			"err", err,
-			"num_txs_to_verify", len(txsFromLane),
 		)
 
 		return proposal, err

--- a/block/base/abci.go
+++ b/block/base/abci.go
@@ -79,13 +79,18 @@ func (l *BaseLane) ProcessLane(
 	txs []sdk.Tx,
 	next block.ProcessLanesHandler,
 ) (proposals.Proposal, error) {
+	l.Logger().Info(
+		"processing lane",
+		"lane", l.Name(),
+		"num_txs_to_verify", len(txs),
+	)
+
 	if len(txs) == 0 {
-		return proposal, nil
+		return next(ctx, proposal, txs)
 	}
 
-	l.Logger().Info("processing lane", "lane", l.Name())
-
-	// Verify the transactions that belong to this lane according to the verification logic of the lane.
+	// Verify the transactions that belong to the lane and return any transactions that must be
+	// validated by the next lane in the chain.
 	txsFromLane, remainingTxs, err := l.processLaneHandler(ctx, txs)
 	if err != nil {
 		l.Logger().Error(
@@ -117,6 +122,7 @@ func (l *BaseLane) ProcessLane(
 		"num_txs_remaining", len(remainingTxs),
 	)
 
+	// Validate the remaining transactions with the next lane in the chain.
 	return next(ctx, proposal, remainingTxs)
 }
 

--- a/block/base/handlers.go
+++ b/block/base/handlers.go
@@ -111,10 +111,10 @@ func (l *BaseLane) DefaultPrepareLaneHandler() PrepareLaneHandler {
 
 // DefaultProcessLaneHandler returns a default implementation of the ProcessLaneHandler. It verifies
 // the following invariants:
-//  1. All transactions belong to this lane. If a transaction does not belong to this lane, we return
-//     the remaining transactions iff there are no matches in the remaining transactions after this index.
-//  2. All transactions respect the priority defined by the mempool.
-//  3. All transactions are valid respecting the verification logic of the lane.
+//  1. Transactions belonging to the lane must be contiguous from the beginning of the partial proposal.
+//  2. Transactions that do not belong to the lane must be contiguous from the end of the partial proposal.
+//  3. Transactions must be ordered respecting the priority defined by the lane (e.g. gas price).
+//  4. Transactions must be valid according to the verification logic of the lane.
 func (l *BaseLane) DefaultProcessLaneHandler() ProcessLaneHandler {
 	return func(ctx sdk.Context, partialProposal []sdk.Tx) ([]sdk.Tx, []sdk.Tx, error) {
 		if len(partialProposal) == 0 {

--- a/block/base/types.go
+++ b/block/base/types.go
@@ -22,12 +22,7 @@ type (
 
 	// ProcessLaneHandler is responsible for processing transactions that are included in a block and
 	// belong to a given lane. The handler must return the transactions that were successfully processed
-	// and the transactions that it cannot process because they belong to a different lane. Basic invariant
-	// checks that are required:
-	// 1. Transactions belonging to the lane must be contiguous from the beginning of the partial proposal.
-	// 2. Transactions that do not belong to the lane must be contiguous from the end of the partial proposal.
-	// 3. Transactions must be ordered respecting the priority defined by the lane (e.g. gas price).
-	// 4. Transactions must be valid according to the verification logic of the lane.
+	// and the transactions that it cannot process because they belong to a different lane.
 	ProcessLaneHandler func(ctx sdk.Context, partialProposal []sdk.Tx) (
 		txsFromLane []sdk.Tx,
 		remainingTxs []sdk.Tx,

--- a/block/base/types.go
+++ b/block/base/types.go
@@ -21,8 +21,13 @@ type (
 	) (txsToInclude []sdk.Tx, txsToRemove []sdk.Tx, err error)
 
 	// ProcessLaneHandler is responsible for processing transactions that are included in a block and
-	// belong to a given lane. This handler must return an error if the transactions are not correctly
-	// ordered, do not belong to this lane, or any other relevant error.
+	// belong to a given lane. The handler must return the transactions that were successfully processed
+	// and the transactions that it cannot process because they belong to a different lane. Basic invariant
+	// checks that are required:
+	// 1. Transactions belonging to the lane must be contiguous from the beginning of the partial proposal.
+	// 2. Transactions that do not belong to the lane must be contiguous from the end of the partial proposal.
+	// 3. Transactions must be ordered respecting the priority defined by the lane (e.g. gas price).
+	// 4. Transactions must be valid according to the verification logic of the lane.
 	ProcessLaneHandler func(ctx sdk.Context, partialProposal []sdk.Tx) (
 		txsFromLane []sdk.Tx,
 		remainingTxs []sdk.Tx,

--- a/block/base/types.go
+++ b/block/base/types.go
@@ -23,7 +23,11 @@ type (
 	// ProcessLaneHandler is responsible for processing transactions that are included in a block and
 	// belong to a given lane. This handler must return an error if the transactions are not correctly
 	// ordered, do not belong to this lane, or any other relevant error.
-	ProcessLaneHandler func(ctx sdk.Context, partialProposal []sdk.Tx) error
+	ProcessLaneHandler func(ctx sdk.Context, partialProposal []sdk.Tx) (
+		txsFromLane []sdk.Tx,
+		remainingTxs []sdk.Tx,
+		err error,
+	)
 )
 
 // NoOpPrepareLaneHandler returns a no-op prepare lane handler.
@@ -45,15 +49,15 @@ func PanicPrepareLaneHandler() PrepareLaneHandler {
 // NoOpProcessLaneHandler returns a no-op process lane handler.
 // This should only be used for testing.
 func NoOpProcessLaneHandler() ProcessLaneHandler {
-	return func(sdk.Context, []sdk.Tx) error {
-		return nil
+	return func(sdk.Context, []sdk.Tx) ([]sdk.Tx, []sdk.Tx, error) {
+		return nil, nil, nil
 	}
 }
 
 // PanicProcessLanesHandler returns a process lanes handler that panics.
 // This should only be used for testing.
 func PanicProcessLaneHandler() ProcessLaneHandler {
-	return func(sdk.Context, []sdk.Tx) error {
+	return func(sdk.Context, []sdk.Tx) ([]sdk.Tx, []sdk.Tx, error) {
 		panic("panic process lanes handler")
 	}
 }

--- a/block/lane.go
+++ b/block/lane.go
@@ -50,7 +50,7 @@ type Lane interface {
 	ProcessLane(
 		ctx sdk.Context,
 		proposal proposals.Proposal,
-		partialProposal [][]byte,
+		txs []sdk.Tx,
 		next ProcessLanesHandler,
 	) (proposals.Proposal, error)
 

--- a/block/mocks/lane.go
+++ b/block/mocks/lane.go
@@ -171,23 +171,23 @@ func (_m *Lane) PrepareLane(ctx types.Context, proposal proposals.Proposal, next
 	return r0, r1
 }
 
-// ProcessLane provides a mock function with given fields: ctx, proposal, partialProposal, next
-func (_m *Lane) ProcessLane(ctx types.Context, proposal proposals.Proposal, partialProposal [][]byte, next block.ProcessLanesHandler) (proposals.Proposal, error) {
-	ret := _m.Called(ctx, proposal, partialProposal, next)
+// ProcessLane provides a mock function with given fields: ctx, proposal, txs, next
+func (_m *Lane) ProcessLane(ctx types.Context, proposal proposals.Proposal, txs []types.Tx, next block.ProcessLanesHandler) (proposals.Proposal, error) {
+	ret := _m.Called(ctx, proposal, txs, next)
 
 	var r0 proposals.Proposal
 	var r1 error
-	if rf, ok := ret.Get(0).(func(types.Context, proposals.Proposal, [][]byte, block.ProcessLanesHandler) (proposals.Proposal, error)); ok {
-		return rf(ctx, proposal, partialProposal, next)
+	if rf, ok := ret.Get(0).(func(types.Context, proposals.Proposal, []types.Tx, block.ProcessLanesHandler) (proposals.Proposal, error)); ok {
+		return rf(ctx, proposal, txs, next)
 	}
-	if rf, ok := ret.Get(0).(func(types.Context, proposals.Proposal, [][]byte, block.ProcessLanesHandler) proposals.Proposal); ok {
-		r0 = rf(ctx, proposal, partialProposal, next)
+	if rf, ok := ret.Get(0).(func(types.Context, proposals.Proposal, []types.Tx, block.ProcessLanesHandler) proposals.Proposal); ok {
+		r0 = rf(ctx, proposal, txs, next)
 	} else {
 		r0 = ret.Get(0).(proposals.Proposal)
 	}
 
-	if rf, ok := ret.Get(1).(func(types.Context, proposals.Proposal, [][]byte, block.ProcessLanesHandler) error); ok {
-		r1 = rf(ctx, proposal, partialProposal, next)
+	if rf, ok := ret.Get(1).(func(types.Context, proposals.Proposal, []types.Tx, block.ProcessLanesHandler) error); ok {
+		r1 = rf(ctx, proposal, txs, next)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/block/proposals/proposals.go
+++ b/block/proposals/proposals.go
@@ -48,6 +48,9 @@ func NewProposal(logger log.Logger, txEncoder sdk.TxEncoder, maxBlockSize int64,
 
 // GetProposalWithInfo returns all of the transactions in the proposal along with information
 // about the lanes that built the proposal.
+//
+// NOTE: This is currently not used in production but likely will be once
+// ABCI 3.0 is released.
 func (p *Proposal) GetProposalWithInfo() ([][]byte, error) {
 	// Marshall the proposal info into the first slot of the proposal.
 	infoBz, err := p.Info.Marshal()

--- a/block/proposals/update.go
+++ b/block/proposals/update.go
@@ -1,7 +1,6 @@
 package proposals
 
 import (
-	"encoding/base64"
 	"fmt"
 
 	"cosmossdk.io/math"
@@ -55,8 +54,6 @@ func (p *Proposal) UpdateProposal(lane Lane, partialProposal []sdk.Tx) error {
 			"tx_hash", txInfo.Hash,
 			"tx_size", txInfo.Size,
 			"tx_gas_limit", txInfo.GasLimit,
-			"tx_bytes", txInfo.TxBytes,
-			"raw_tx", base64.StdEncoding.EncodeToString(txInfo.TxBytes),
 		)
 
 		// invariant check: Ensure that the transaction is not already in the proposal.

--- a/block/proposals/update.go
+++ b/block/proposals/update.go
@@ -47,7 +47,7 @@ func (p *Proposal) UpdateProposal(lane Lane, partialProposal []sdk.Tx) error {
 			return fmt.Errorf("err retrieving transaction info: %s", err)
 		}
 
-		p.Logger.Debug(
+		p.Logger.Info(
 			"updating proposal with tx",
 			"index", index,
 			"lane", lane.Name(),

--- a/block/types.go
+++ b/block/types.go
@@ -15,7 +15,7 @@ type (
 	// ProcessLanesHandler wraps all of the lanes' ProcessLane functions into a single chained
 	// function. You can think of it like an AnteHandler, but for processing proposals in the
 	// context of lanes instead of modules.
-	ProcessLanesHandler func(ctx sdk.Context, proposal proposals.Proposal) (proposals.Proposal, error)
+	ProcessLanesHandler func(ctx sdk.Context, proposal proposals.Proposal, txs []sdk.Tx) (proposals.Proposal, error)
 )
 
 // NoOpPrepareLanesHandler returns a no-op prepare lanes handler.
@@ -29,7 +29,7 @@ func NoOpPrepareLanesHandler() PrepareLanesHandler {
 // NoOpProcessLanesHandler returns a no-op process lanes handler.
 // This should only be used for testing.
 func NoOpProcessLanesHandler() ProcessLanesHandler {
-	return func(_ sdk.Context, p proposals.Proposal) (proposals.Proposal, error) {
+	return func(_ sdk.Context, p proposals.Proposal, _ []sdk.Tx) (proposals.Proposal, error) {
 		return p, nil
 	}
 }

--- a/block/utils/utils.go
+++ b/block/utils/utils.go
@@ -1,9 +1,11 @@
 package utils
 
 import (
-	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"strings"
+
+	comettypes "github.com/cometbft/cometbft/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkmempool "github.com/cosmos/cosmos-sdk/types/mempool"
@@ -31,8 +33,7 @@ func GetTxInfo(txEncoder sdk.TxEncoder, tx sdk.Tx) (TxInfo, error) {
 		return TxInfo{}, fmt.Errorf("failed to encode transaction: %w", err)
 	}
 
-	txHash := sha256.Sum256(txBz)
-	txHashStr := hex.EncodeToString(txHash[:])
+	txHashStr := strings.ToUpper(hex.EncodeToString(comettypes.Tx(txBz).Hash()))
 
 	// TODO: Add an adapter to lanes so that this can be flexible to support EVM, etc.
 	gasTx, ok := tx.(sdk.FeeTx)

--- a/lanes/base/abci_test.go
+++ b/lanes/base/abci_test.go
@@ -10,6 +10,7 @@ import (
 	"cosmossdk.io/log"
 	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/mock"
 
 	signer_extraction "github.com/skip-mev/block-sdk/adapters/signer_extraction_adapter"
 	"github.com/skip-mev/block-sdk/block"
@@ -560,9 +561,6 @@ func (s *BaseTestSuite) TestProcessLane() {
 			},
 		)
 
-		partialProposal, err := utils.GetEncodedTxs(s.encodingConfig.TxConfig.TxEncoder(), proposal)
-		s.Require().NoError(err)
-
 		emptyProposal := proposals.NewProposal(
 			log.NewNopLogger(),
 			s.encodingConfig.TxConfig.TxEncoder(),
@@ -570,7 +568,8 @@ func (s *BaseTestSuite) TestProcessLane() {
 			100000,
 		)
 
-		_, err = lane.ProcessLane(s.ctx, emptyProposal, partialProposal, block.NoOpProcessLanesHandler())
+		finalProposal, err := lane.ProcessLane(s.ctx, emptyProposal, proposal, block.NoOpProcessLanesHandler())
+		s.Require().Len(finalProposal.Txs, 2)
 		s.Require().NoError(err)
 	})
 
@@ -623,9 +622,6 @@ func (s *BaseTestSuite) TestProcessLane() {
 			},
 		)
 
-		partialProposal, err := utils.GetEncodedTxs(s.encodingConfig.TxConfig.TxEncoder(), proposal)
-		s.Require().NoError(err)
-
 		emptyProposal := proposals.NewProposal(
 			log.NewNopLogger(),
 			s.encodingConfig.TxConfig.TxEncoder(),
@@ -633,7 +629,8 @@ func (s *BaseTestSuite) TestProcessLane() {
 			100000,
 		)
 
-		_, err = lane.ProcessLane(s.ctx, emptyProposal, partialProposal, block.NoOpProcessLanesHandler())
+		finalProposal, err := lane.ProcessLane(s.ctx, emptyProposal, proposal, block.NoOpProcessLanesHandler())
+		s.Require().Len(finalProposal.Txs, 3)
 		s.Require().NoError(err)
 	})
 
@@ -699,9 +696,6 @@ func (s *BaseTestSuite) TestProcessLane() {
 			},
 		)
 
-		partialProposal, err := utils.GetEncodedTxs(s.encodingConfig.TxConfig.TxEncoder(), proposal)
-		s.Require().NoError(err)
-
 		emptyProposal := proposals.NewProposal(
 			log.NewNopLogger(),
 			s.encodingConfig.TxConfig.TxEncoder(),
@@ -709,11 +703,12 @@ func (s *BaseTestSuite) TestProcessLane() {
 			100000,
 		)
 
-		_, err = lane.ProcessLane(s.ctx, emptyProposal, partialProposal, block.NoOpProcessLanesHandler())
+		finalProposal, err := lane.ProcessLane(s.ctx, emptyProposal, proposal, block.NoOpProcessLanesHandler())
+		s.Require().Len(finalProposal.Txs, 4)
 		s.Require().NoError(err)
 	})
 
-	s.Run("should accept a proposal with valid transactions", func() {
+	s.Run("should accept a proposal with a single valid transaction", func() {
 		tx1, err := testutils.CreateRandomTx(
 			s.encodingConfig.TxConfig,
 			s.accounts[0],
@@ -735,9 +730,6 @@ func (s *BaseTestSuite) TestProcessLane() {
 			},
 		)
 
-		partialProposal, err := utils.GetEncodedTxs(s.encodingConfig.TxConfig.TxEncoder(), proposal)
-		s.Require().NoError(err)
-
 		emptyProposal := proposals.NewProposal(
 			log.NewNopLogger(),
 			s.encodingConfig.TxConfig.TxEncoder(),
@@ -745,7 +737,8 @@ func (s *BaseTestSuite) TestProcessLane() {
 			100000,
 		)
 
-		_, err = lane.ProcessLane(s.ctx, emptyProposal, partialProposal, block.NoOpProcessLanesHandler())
+		finalProposal, err := lane.ProcessLane(s.ctx, emptyProposal, proposal, block.NoOpProcessLanesHandler())
+		s.Require().Len(finalProposal.Txs, 1)
 		s.Require().NoError(err)
 	})
 
@@ -771,9 +764,6 @@ func (s *BaseTestSuite) TestProcessLane() {
 			},
 		)
 
-		partialProposal, err := utils.GetEncodedTxs(s.encodingConfig.TxConfig.TxEncoder(), proposal)
-		s.Require().NoError(err)
-
 		emptyProposal := proposals.NewProposal(
 			log.NewNopLogger(),
 			s.encodingConfig.TxConfig.TxEncoder(),
@@ -781,7 +771,7 @@ func (s *BaseTestSuite) TestProcessLane() {
 			100000,
 		)
 
-		_, err = lane.ProcessLane(s.ctx, emptyProposal, partialProposal, block.NoOpProcessLanesHandler())
+		_, err = lane.ProcessLane(s.ctx, emptyProposal, proposal, block.NoOpProcessLanesHandler())
 		s.Require().Error(err)
 	})
 
@@ -828,10 +818,8 @@ func (s *BaseTestSuite) TestProcessLane() {
 				tx1: true,
 				tx2: false,
 				tx3: true,
-			})
-
-		partialProposal, err := utils.GetEncodedTxs(s.encodingConfig.TxConfig.TxEncoder(), proposal)
-		s.Require().NoError(err)
+			},
+		)
 
 		emptyProposal := proposals.NewProposal(
 			log.NewNopLogger(),
@@ -840,7 +828,7 @@ func (s *BaseTestSuite) TestProcessLane() {
 			100000,
 		)
 
-		_, err = lane.ProcessLane(s.ctx, emptyProposal, partialProposal, block.NoOpProcessLanesHandler())
+		_, err = lane.ProcessLane(s.ctx, emptyProposal, proposal, block.NoOpProcessLanesHandler())
 		s.Require().Error(err)
 	})
 
@@ -877,10 +865,8 @@ func (s *BaseTestSuite) TestProcessLane() {
 			map[sdk.Tx]bool{
 				tx1: true,
 				tx2: true,
-			})
-
-		partialProposal, err := utils.GetEncodedTxs(s.encodingConfig.TxConfig.TxEncoder(), proposal)
-		s.Require().NoError(err)
+			},
+		)
 
 		emptyProposal := proposals.NewProposal(
 			log.NewNopLogger(),
@@ -889,11 +875,12 @@ func (s *BaseTestSuite) TestProcessLane() {
 			100000,
 		)
 
-		_, err = lane.ProcessLane(s.ctx, emptyProposal, partialProposal, block.NoOpProcessLanesHandler())
+		finalProposal, err := lane.ProcessLane(s.ctx, emptyProposal, proposal, block.NoOpProcessLanesHandler())
+		s.Require().Len(finalProposal.Txs, 2)
 		s.Require().NoError(err)
 	})
 
-	s.Run("should not accept a proposal with transactions that are not in the correct order", func() {
+	s.Run("should not accept a proposal with transactions that are not in the correct order fee wise", func() {
 		tx1, err := testutils.CreateRandomTx(
 			s.encodingConfig.TxConfig,
 			s.accounts[0],
@@ -928,9 +915,6 @@ func (s *BaseTestSuite) TestProcessLane() {
 				tx2: true,
 			})
 
-		partialProposal, err := utils.GetEncodedTxs(s.encodingConfig.TxConfig.TxEncoder(), proposal)
-		s.Require().NoError(err)
-
 		emptyProposal := proposals.NewProposal(
 			log.NewNopLogger(),
 			s.encodingConfig.TxConfig.TxEncoder(),
@@ -938,7 +922,7 @@ func (s *BaseTestSuite) TestProcessLane() {
 			100000,
 		)
 
-		_, err = lane.ProcessLane(s.ctx, emptyProposal, partialProposal, block.NoOpProcessLanesHandler())
+		_, err = lane.ProcessLane(s.ctx, emptyProposal, proposal, block.NoOpProcessLanesHandler())
 		s.Require().Error(err)
 	})
 
@@ -965,7 +949,19 @@ func (s *BaseTestSuite) TestProcessLane() {
 		)
 		s.Require().NoError(err)
 
-		otherLane := s.initLane(math.LegacyOneDec(), nil)
+		// First lane matches this lane the other does not.
+		otherLane := mocks.NewLane(s.T())
+		otherLane.On(
+			"Match",
+			mock.Anything,
+			tx1,
+		).Return(true, nil)
+
+		otherLane.On(
+			"Match",
+			mock.Anything,
+			tx2,
+		).Return(false, nil)
 
 		lane := s.initLane(
 			math.LegacyOneDec(),
@@ -980,9 +976,6 @@ func (s *BaseTestSuite) TestProcessLane() {
 			tx2,
 		}
 
-		partialProposal, err := utils.GetEncodedTxs(s.encodingConfig.TxConfig.TxEncoder(), proposal)
-		s.Require().NoError(err)
-
 		emptyProposal := proposals.NewProposal(
 			log.NewNopLogger(),
 			s.encodingConfig.TxConfig.TxEncoder(),
@@ -990,7 +983,7 @@ func (s *BaseTestSuite) TestProcessLane() {
 			100000,
 		)
 
-		_, err = lane.ProcessLane(s.ctx, emptyProposal, partialProposal, block.NoOpProcessLanesHandler())
+		_, err = lane.ProcessLane(s.ctx, emptyProposal, proposal, block.NoOpProcessLanesHandler())
 		s.Require().Error(err)
 	})
 
@@ -1016,8 +1009,6 @@ func (s *BaseTestSuite) TestProcessLane() {
 			})
 
 		maxSize := s.getTxSize(tx1) - 1
-		partialProposal, err := utils.GetEncodedTxs(s.encodingConfig.TxConfig.TxEncoder(), proposal)
-		s.Require().NoError(err)
 
 		emptyProposal := proposals.NewProposal(
 			log.NewNopLogger(),
@@ -1026,7 +1017,7 @@ func (s *BaseTestSuite) TestProcessLane() {
 			1000000,
 		)
 
-		_, err = lane.ProcessLane(s.ctx, emptyProposal, partialProposal, block.NoOpProcessLanesHandler())
+		_, err = lane.ProcessLane(s.ctx, emptyProposal, proposal, block.NoOpProcessLanesHandler())
 		s.Require().Error(err)
 	})
 
@@ -1053,8 +1044,6 @@ func (s *BaseTestSuite) TestProcessLane() {
 		)
 
 		maxSize := s.getTxSize(tx1)
-		partialProposal, err := utils.GetEncodedTxs(s.encodingConfig.TxConfig.TxEncoder(), proposal)
-		s.Require().NoError(err)
 
 		emptyProposal := proposals.NewProposal(
 			log.NewNopLogger(),
@@ -1063,7 +1052,7 @@ func (s *BaseTestSuite) TestProcessLane() {
 			9,
 		)
 
-		_, err = lane.ProcessLane(s.ctx, emptyProposal, partialProposal, block.NoOpProcessLanesHandler())
+		_, err = lane.ProcessLane(s.ctx, emptyProposal, proposal, block.NoOpProcessLanesHandler())
 		s.Require().Error(err)
 	})
 
@@ -1101,8 +1090,6 @@ func (s *BaseTestSuite) TestProcessLane() {
 			})
 
 		maxSize := s.getTxSize(tx1) + s.getTxSize(tx2)
-		partialProposal, err := utils.GetEncodedTxs(s.encodingConfig.TxConfig.TxEncoder(), proposal)
-		s.Require().NoError(err)
 
 		emptyProposal := proposals.NewProposal(
 			log.NewNopLogger(),
@@ -1111,7 +1098,7 @@ func (s *BaseTestSuite) TestProcessLane() {
 			19,
 		)
 
-		_, err = lane.ProcessLane(s.ctx, emptyProposal, partialProposal, block.NoOpProcessLanesHandler())
+		_, err = lane.ProcessLane(s.ctx, emptyProposal, proposal, block.NoOpProcessLanesHandler())
 		s.Require().Error(err)
 	})
 
@@ -1150,8 +1137,6 @@ func (s *BaseTestSuite) TestProcessLane() {
 		)
 
 		maxSize := s.getTxSize(tx1) + s.getTxSize(tx2) - 1
-		partialProposal, err := utils.GetEncodedTxs(s.encodingConfig.TxConfig.TxEncoder(), proposal)
-		s.Require().NoError(err)
 
 		emptyProposal := proposals.NewProposal(
 			log.NewNopLogger(),
@@ -1160,8 +1145,193 @@ func (s *BaseTestSuite) TestProcessLane() {
 			20,
 		)
 
-		_, err = lane.ProcessLane(s.ctx, emptyProposal, partialProposal, block.NoOpProcessLanesHandler())
+		_, err = lane.ProcessLane(s.ctx, emptyProposal, proposal, block.NoOpProcessLanesHandler())
 		s.Require().Error(err)
+	})
+
+	s.Run("contiguous set of transactions should be accepted with other transactions that do not match", func() {
+		tx1, err := testutils.CreateRandomTx(
+			s.encodingConfig.TxConfig,
+			s.accounts[0],
+			1,
+			1,
+			0,
+			1,
+		)
+		s.Require().NoError(err)
+
+		tx2, err := testutils.CreateRandomTx(
+			s.encodingConfig.TxConfig,
+			s.accounts[1],
+			2,
+			1,
+			0,
+			1,
+		)
+		s.Require().NoError(err)
+
+		tx3, err := testutils.CreateRandomTx(
+			s.encodingConfig.TxConfig,
+			s.accounts[2],
+			3,
+			1,
+			0,
+			1,
+		)
+		s.Require().NoError(err)
+
+		tx4, err := testutils.CreateRandomTx(
+			s.encodingConfig.TxConfig,
+			s.accounts[3],
+			4,
+			1,
+			0,
+			1,
+		)
+		s.Require().NoError(err)
+
+		proposal := []sdk.Tx{
+			tx1,
+			tx2,
+			tx3,
+			tx4,
+		}
+
+		otherLane := mocks.NewLane(s.T())
+		otherLane.On(
+			"Match",
+			mock.Anything,
+			tx1,
+		).Return(false, nil)
+
+		otherLane.On(
+			"Match",
+			mock.Anything,
+			tx2,
+		).Return(false, nil)
+
+		otherLane.On(
+			"Match",
+			mock.Anything,
+			tx3,
+		).Return(true, nil)
+
+		otherLane.On(
+			"Match",
+			mock.Anything,
+			tx4,
+		).Return(true, nil)
+
+		lane := s.initLane(
+			math.LegacyOneDec(),
+			map[sdk.Tx]bool{
+				tx1: true,
+				tx2: true,
+			},
+		)
+		lane.SetIgnoreList([]block.Lane{otherLane})
+
+		emptyProposal := proposals.NewProposal(
+			log.NewNopLogger(),
+			s.encodingConfig.TxConfig.TxEncoder(),
+			1000,
+			1000,
+		)
+
+		finalProposal, err := lane.ProcessLane(s.ctx, emptyProposal, proposal, block.NoOpProcessLanesHandler())
+		s.Require().NoError(err)
+		s.Require().Len(finalProposal.Txs, 2)
+	})
+
+	s.Run("returns no error if transactions belong to a different lane", func() {
+		tx1, err := testutils.CreateRandomTx(
+			s.encodingConfig.TxConfig,
+			s.accounts[0],
+			1,
+			1,
+			0,
+			1,
+		)
+		s.Require().NoError(err)
+
+		tx2, err := testutils.CreateRandomTx(
+			s.encodingConfig.TxConfig,
+			s.accounts[1],
+			2,
+			1,
+			0,
+			1,
+		)
+		s.Require().NoError(err)
+
+		tx3, err := testutils.CreateRandomTx(
+			s.encodingConfig.TxConfig,
+			s.accounts[2],
+			3,
+			1,
+			0,
+			1,
+		)
+		s.Require().NoError(err)
+
+		tx4, err := testutils.CreateRandomTx(
+			s.encodingConfig.TxConfig,
+			s.accounts[3],
+			4,
+			1,
+			0,
+			1,
+		)
+		s.Require().NoError(err)
+
+		proposal := []sdk.Tx{
+			tx1,
+			tx2,
+			tx3,
+			tx4,
+		}
+
+		otherLane := mocks.NewLane(s.T())
+		otherLane.On(
+			"Match",
+			mock.Anything,
+			tx1,
+		).Return(true, nil)
+
+		otherLane.On(
+			"Match",
+			mock.Anything,
+			tx2,
+		).Return(true, nil)
+
+		otherLane.On(
+			"Match",
+			mock.Anything,
+			tx3,
+		).Return(true, nil)
+
+		otherLane.On(
+			"Match",
+			mock.Anything,
+			tx4,
+		).Return(true, nil)
+
+		lane := s.initLane(
+			math.LegacyOneDec(),
+			map[sdk.Tx]bool{},
+		)
+		lane.SetIgnoreList([]block.Lane{otherLane})
+
+		emptyProposal := proposals.NewProposal(
+			log.NewNopLogger(),
+			s.encodingConfig.TxConfig.TxEncoder(),
+			1000,
+			1000,
+		)
+
+		finalProposal, err := lane.ProcessLane(s.ctx, emptyProposal, proposal, block.NoOpProcessLanesHandler())
+		s.Require().NoError(err)
+		s.Require().Len(finalProposal.Txs, 0)
 	})
 }
 
@@ -1222,6 +1392,9 @@ func (s *BaseTestSuite) TestPrepareProcessParity() {
 		s.Require().Equal(bz, proposal.Txs[i])
 	}
 
+	decodedTxs, err := utils.GetDecodedTxs(s.encodingConfig.TxConfig.TxDecoder(), proposal.Txs)
+	s.Require().NoError(err)
+
 	// Verify the same proposal with the process lanes handler
 	emptyProposal = proposals.NewProposal(
 		log.NewNopLogger(),
@@ -1229,7 +1402,7 @@ func (s *BaseTestSuite) TestPrepareProcessParity() {
 		1000000000000000,
 		1000000000000000,
 	)
-	proposal, err = lane.ProcessLane(s.ctx, emptyProposal, proposal.Txs, block.NoOpProcessLanesHandler())
+	proposal, err = lane.ProcessLane(s.ctx, emptyProposal, decodedTxs, block.NoOpProcessLanesHandler())
 	s.Require().NoError(err)
 	s.Require().Equal(len(txsToInsert), len(proposal.Txs))
 	s.T().Logf("proposal num txs: %d", len(proposal.Txs))
@@ -1282,17 +1455,14 @@ func (s *BaseTestSuite) TestIterateMempoolAndProcessProposalParity() {
 
 	s.Require().Equal(len(txsToInsert), len(retrievedTxs))
 
-	partialProposal, err := utils.GetEncodedTxs(s.encodingConfig.TxConfig.TxEncoder(), retrievedTxs)
-	s.Require().NoError(err)
-
 	emptyProposal := proposals.NewProposal(
-		log.NewNopLogger(),
+		log.NewTestLogger(s.T()),
 		s.encodingConfig.TxConfig.TxEncoder(),
 		1000000000000000,
 		1000000000000000,
 	)
 
-	proposal, err := lane.ProcessLane(s.ctx, emptyProposal, partialProposal, block.NoOpProcessLanesHandler())
+	proposal, err := lane.ProcessLane(s.ctx, emptyProposal, retrievedTxs, block.NoOpProcessLanesHandler())
 	s.Require().NoError(err)
 	s.Require().Equal(len(txsToInsert), len(proposal.Txs))
 	s.T().Logf("proposal num txs: %d", len(proposal.Txs))
@@ -1310,7 +1480,7 @@ func (s *BaseTestSuite) initLane(
 	expectedExecution map[sdk.Tx]bool,
 ) *defaultlane.DefaultLane {
 	config := base.NewLaneConfig(
-		log.NewNopLogger(),
+		log.NewTestLogger(s.T()),
 		s.encodingConfig.TxConfig.TxEncoder(),
 		s.encodingConfig.TxConfig.TxDecoder(),
 		s.setUpAnteHandler(expectedExecution),

--- a/lanes/mev/abci.go
+++ b/lanes/mev/abci.go
@@ -77,73 +77,80 @@ func (l *MEVLane) PrepareLaneHandler() base.PrepareLaneHandler {
 
 // ProcessLaneHandler will ensure that block proposals that include transactions from
 // the mev lane are valid. In particular, the invariant checks that we perform are:
-//  1. The first transaction in the partial block proposal must be a bid transaction.
+//  1. If the first transaction does not match the lane, no other MEV transactions
+//     should be included in the proposal.
 //  2. The bid transaction must be valid.
 //  3. The bundled transactions must be valid.
 //  4. The bundled transactions must match the transactions in the block proposal in the
 //     same order they were defined in the bid transaction.
 //  5. The bundled transactions must not be bid transactions.
 func (l *MEVLane) ProcessLaneHandler() base.ProcessLaneHandler {
-	return func(ctx sdk.Context, partialProposal []sdk.Tx) error {
+	return func(ctx sdk.Context, partialProposal []sdk.Tx) ([]sdk.Tx, []sdk.Tx, error) {
 		if len(partialProposal) == 0 {
-			return nil
+			return nil, nil, nil
 		}
 
-		// If the first transaction does not match the lane, then we return an error.
+		// If the first transaction does not match the lane, no other MEV transactions
+		// should be included in the proposal.
 		bidTx := partialProposal[0]
 		if !l.Match(ctx, bidTx) {
-			return fmt.Errorf("expected first transaction in lane %s to be a bid transaction", l.Name())
+			if err := l.VerifyNoMatches(ctx, partialProposal[1:]); err != nil {
+				return nil, nil, fmt.Errorf("failed to verify no matches: %w", err)
+			}
+
+			return nil, partialProposal, nil
 		}
 
 		bidInfo, err := l.GetAuctionBidInfo(bidTx)
 		if err != nil {
-			return fmt.Errorf("failed to get bid info from auction bid tx for lane %s: %w", l.Name(), err)
+			return nil, nil, fmt.Errorf("failed to get bid info from auction bid tx for lane %s: %w", l.Name(), err)
 		}
 
 		if bidInfo == nil {
-			return fmt.Errorf("bid info is nil")
+			return nil, nil, fmt.Errorf("bid info is nil")
 		}
 
 		// Check that all bundled transactions were included.
-		if len(bidInfo.Transactions)+1 != len(partialProposal) {
-			return fmt.Errorf(
+		bundleSize := len(bidInfo.Transactions) + 1
+		if bundleSize > len(partialProposal) {
+			return nil, nil, fmt.Errorf(
 				"expected %d transactions in lane %s but got %d",
-				len(bidInfo.Transactions)+1,
+				bundleSize,
 				l.Name(),
 				len(partialProposal),
 			)
 		}
 
 		// Ensure the transactions in the proposal match the bundled transactions in the bid transaction.
-		bundle := partialProposal[1:]
+		bundle := partialProposal[1:bundleSize]
 		for index, bundledTxBz := range bidInfo.Transactions {
 			bundledTx, err := l.WrapBundleTransaction(bundledTxBz)
 			if err != nil {
-				return fmt.Errorf("invalid bid tx; failed to decode bundled tx: %w", err)
+				return nil, nil, fmt.Errorf("invalid bid tx; failed to decode bundled tx: %w", err)
 			}
 
 			expectedTxBz, err := l.TxEncoder()(bundledTx)
 			if err != nil {
-				return fmt.Errorf("invalid bid tx; failed to encode bundled tx: %w", err)
+				return nil, nil, fmt.Errorf("invalid bid tx; failed to encode bundled tx: %w", err)
 			}
 
 			actualTxBz, err := l.TxEncoder()(bundle[index])
 			if err != nil {
-				return fmt.Errorf("invalid bid tx; failed to encode tx: %w", err)
+				return nil, nil, fmt.Errorf("invalid bid tx; failed to encode tx: %w", err)
 			}
 
 			// Verify that the bundled transaction matches the transaction in the block proposal.
 			if !bytes.Equal(actualTxBz, expectedTxBz) {
-				return fmt.Errorf("invalid bid tx; bundled tx does not match tx in block proposal")
+				return nil, nil, fmt.Errorf("invalid bid tx; bundled tx does not match tx in block proposal")
 			}
 		}
 
 		// Verify the top-level bid transaction.
 		if err := l.VerifyBidTx(ctx, bidTx, bundle); err != nil {
-			return fmt.Errorf("invalid bid tx; failed to verify bid tx: %w", err)
+			return nil, nil, fmt.Errorf("invalid bid tx; failed to verify bid tx: %w", err)
 		}
 
-		return nil
+		return partialProposal[:bundleSize], partialProposal[bundleSize:], nil
 	}
 }
 

--- a/lanes/mev/abci.go
+++ b/lanes/mev/abci.go
@@ -90,8 +90,6 @@ func (l *MEVLane) ProcessLaneHandler() base.ProcessLaneHandler {
 			return nil, nil, nil
 		}
 
-		// If the first transaction does not match the lane, no other MEV transactions
-		// should be included in the proposal.
 		bidTx := partialProposal[0]
 		if !l.Match(ctx, bidTx) {
 			// If the transaction does not belong to this lane, we return the remaining transactions

--- a/lanes/mev/abci_test.go
+++ b/lanes/mev/abci_test.go
@@ -230,12 +230,14 @@ func (s *MEVTestSuite) TestProcessLane() {
 		lane := s.initLane(math.LegacyOneDec(), nil)
 		proposal := proposals.NewProposal(log.NewNopLogger(), s.encCfg.TxConfig.TxEncoder(), 200, 100)
 
-		proposal, err := lane.ProcessLane(s.ctx, proposal, nil, block.NoOpProcessLanesHandler())
+		txsFromLane, remainingTxs, err := lane.ProcessLaneHandler()(s.ctx, nil)
+		s.Require().NoError(err)
+		s.Require().Equal(0, len(txsFromLane))
+		s.Require().Equal(0, len(remainingTxs))
+
+		proposal, err = lane.ProcessLane(s.ctx, proposal, nil, block.NoOpProcessLanesHandler())
 		s.Require().NoError(err)
 		s.Require().Equal(0, len(proposal.Txs))
-		s.Require().Equal(0, len(proposal.Info.TxsByLane))
-		s.Require().Equal(int64(0), proposal.Info.BlockSize)
-		s.Require().Equal(uint64(0), proposal.Info.GasLimit)
 	})
 
 	s.Run("can process a proposal with tx that does not belong to this lane", func() {
@@ -244,6 +246,11 @@ func (s *MEVTestSuite) TestProcessLane() {
 
 		lane := s.initLane(math.LegacyOneDec(), nil)
 		proposal := proposals.NewProposal(log.NewNopLogger(), s.encCfg.TxConfig.TxEncoder(), 200, 100)
+
+		txsFromLane, remainingTxs, err := lane.ProcessLaneHandler()(s.ctx, []sdk.Tx{tx})
+		s.Require().NoError(err)
+		s.Require().Equal(0, len(txsFromLane))
+		s.Require().Equal(1, len(remainingTxs))
 
 		finalProposal, err := lane.ProcessLane(s.ctx, proposal, []sdk.Tx{tx}, block.NoOpProcessLanesHandler())
 		s.Require().NoError(err)
@@ -265,8 +272,13 @@ func (s *MEVTestSuite) TestProcessLane() {
 		partialProposal := []sdk.Tx{bidTx}
 
 		lane := s.initLane(math.LegacyOneDec(), map[sdk.Tx]bool{bidTx: false})
-		proposal := proposals.NewProposal(log.NewNopLogger(), s.encCfg.TxConfig.TxEncoder(), 200000, 1000000)
 
+		txsFromLane, remainingTxs, err := lane.ProcessLaneHandler()(s.ctx, partialProposal)
+		s.Require().Error(err)
+		s.Require().Equal(0, len(txsFromLane))
+		s.Require().Equal(0, len(remainingTxs))
+
+		proposal := proposals.NewProposal(log.NewNopLogger(), s.encCfg.TxConfig.TxEncoder(), 200000, 1000000)
 		_, err = lane.ProcessLane(s.ctx, proposal, partialProposal, block.NoOpProcessLanesHandler())
 		s.Require().Error(err)
 	})
@@ -286,8 +298,13 @@ func (s *MEVTestSuite) TestProcessLane() {
 		partialProposal := []sdk.Tx{bidTx, bundle[0], bundle[1]}
 
 		lane := s.initLane(math.LegacyOneDec(), map[sdk.Tx]bool{bidTx: true, bundle[0]: true, bundle[1]: false})
-		proposal := proposals.NewProposal(log.NewNopLogger(), s.encCfg.TxConfig.TxEncoder(), 200000, 1000000)
 
+		txsFromLane, remainingTxs, err := lane.ProcessLaneHandler()(s.ctx, partialProposal)
+		s.Require().Error(err)
+		s.Require().Equal(0, len(txsFromLane))
+		s.Require().Equal(0, len(remainingTxs))
+
+		proposal := proposals.NewProposal(log.NewNopLogger(), s.encCfg.TxConfig.TxEncoder(), 200000, 1000000)
 		_, err = lane.ProcessLane(s.ctx, proposal, partialProposal, block.NoOpProcessLanesHandler())
 		s.Require().Error(err)
 	})
@@ -307,8 +324,13 @@ func (s *MEVTestSuite) TestProcessLane() {
 		partialProposal := []sdk.Tx{bidTx, bundle[1], bundle[0]}
 
 		lane := s.initLane(math.LegacyOneDec(), map[sdk.Tx]bool{bidTx: true, bundle[0]: true, bundle[1]: true})
-		proposal := proposals.NewProposal(log.NewNopLogger(), s.encCfg.TxConfig.TxEncoder(), 200000, 1000000)
 
+		txsFromLane, remainingTxs, err := lane.ProcessLaneHandler()(s.ctx, partialProposal)
+		s.Require().Error(err)
+		s.Require().Equal(0, len(txsFromLane))
+		s.Require().Equal(0, len(remainingTxs))
+
+		proposal := proposals.NewProposal(log.NewNopLogger(), s.encCfg.TxConfig.TxEncoder(), 200000, 1000000)
 		_, err = lane.ProcessLane(s.ctx, proposal, partialProposal, block.NoOpProcessLanesHandler())
 		s.Require().Error(err)
 	})
@@ -328,8 +350,13 @@ func (s *MEVTestSuite) TestProcessLane() {
 		partialProposal := []sdk.Tx{bidTx, bundle[0]}
 
 		lane := s.initLane(math.LegacyOneDec(), map[sdk.Tx]bool{bidTx: true, bundle[0]: true})
-		proposal := proposals.NewProposal(log.NewNopLogger(), s.encCfg.TxConfig.TxEncoder(), 200000, 1000000)
 
+		txsFromLane, remainingTxs, err := lane.ProcessLaneHandler()(s.ctx, partialProposal)
+		s.Require().Error(err)
+		s.Require().Equal(0, len(txsFromLane))
+		s.Require().Equal(0, len(remainingTxs))
+
+		proposal := proposals.NewProposal(log.NewNopLogger(), s.encCfg.TxConfig.TxEncoder(), 200000, 1000000)
 		_, err = lane.ProcessLane(s.ctx, proposal, partialProposal, block.NoOpProcessLanesHandler())
 		s.Require().Error(err)
 	})
@@ -349,8 +376,13 @@ func (s *MEVTestSuite) TestProcessLane() {
 		partialProposal := []sdk.Tx{bidTx, bundle[0], bundle[1]}
 
 		lane := s.initLane(math.LegacyOneDec(), map[sdk.Tx]bool{bidTx: true, bundle[0]: true, bundle[1]: true})
-		proposal := proposals.NewProposal(log.NewNopLogger(), s.encCfg.TxConfig.TxEncoder(), 200000, 1000000)
 
+		txsFromLane, remainingTxs, err := lane.ProcessLaneHandler()(s.ctx, partialProposal)
+		s.Require().NoError(err)
+		s.Require().Equal(3, len(txsFromLane))
+		s.Require().Equal(0, len(remainingTxs))
+
+		proposal := proposals.NewProposal(log.NewNopLogger(), s.encCfg.TxConfig.TxEncoder(), 200000, 1000000)
 		_, err = lane.ProcessLane(s.ctx, proposal, partialProposal, block.NoOpProcessLanesHandler())
 		s.Require().NoError(err)
 	})
@@ -370,8 +402,13 @@ func (s *MEVTestSuite) TestProcessLane() {
 		partialProposal := []sdk.Tx{bidTx}
 
 		lane := s.initLane(math.LegacyOneDec(), map[sdk.Tx]bool{bidTx: true})
-		proposal := proposals.NewProposal(log.NewNopLogger(), s.encCfg.TxConfig.TxEncoder(), 200000, 1000000)
 
+		txsFromLane, remainingTxs, err := lane.ProcessLaneHandler()(s.ctx, partialProposal)
+		s.Require().NoError(err)
+		s.Require().Equal(1, len(txsFromLane))
+		s.Require().Equal(0, len(remainingTxs))
+
+		proposal := proposals.NewProposal(log.NewNopLogger(), s.encCfg.TxConfig.TxEncoder(), 200000, 1000000)
 		_, err = lane.ProcessLane(s.ctx, proposal, partialProposal, block.NoOpProcessLanesHandler())
 		s.Require().NoError(err)
 	})
@@ -391,8 +428,13 @@ func (s *MEVTestSuite) TestProcessLane() {
 		partialProposal := []sdk.Tx{bidTx, bundle[0], bundle[1]}
 
 		lane := s.initLane(math.LegacyOneDec(), map[sdk.Tx]bool{bidTx: true, bundle[0]: true, bundle[1]: true})
-		proposal := proposals.NewProposal(log.NewNopLogger(), s.encCfg.TxConfig.TxEncoder(), 20000, 99)
 
+		txsFromLane, remainingTxs, err := lane.ProcessLaneHandler()(s.ctx, partialProposal)
+		s.Require().NoError(err)
+		s.Require().Equal(3, len(txsFromLane))
+		s.Require().Equal(0, len(remainingTxs))
+
+		proposal := proposals.NewProposal(log.NewNopLogger(), s.encCfg.TxConfig.TxEncoder(), 20000, 99)
 		_, err = lane.ProcessLane(s.ctx, proposal, partialProposal, block.NoOpProcessLanesHandler())
 		s.Require().Error(err)
 	})
@@ -412,8 +454,77 @@ func (s *MEVTestSuite) TestProcessLane() {
 		partialProposal := []sdk.Tx{bidTx, bundle[0], bundle[1]}
 
 		lane := s.initLane(math.LegacyOneDec(), map[sdk.Tx]bool{bidTx: true, bundle[0]: true, bundle[1]: true})
-		proposal := proposals.NewProposal(log.NewNopLogger(), s.encCfg.TxConfig.TxEncoder(), 200, 100)
 
+		txsFromLane, remainingTxs, err := lane.ProcessLaneHandler()(s.ctx, partialProposal)
+		s.Require().NoError(err)
+		s.Require().Equal(3, len(txsFromLane))
+		s.Require().Equal(0, len(remainingTxs))
+
+		proposal := proposals.NewProposal(log.NewNopLogger(), s.encCfg.TxConfig.TxEncoder(), 200, 100)
+		_, err = lane.ProcessLane(s.ctx, proposal, partialProposal, block.NoOpProcessLanesHandler())
+		s.Require().Error(err)
+	})
+
+	s.Run("can accept a block proposal with bid and other txs", func() {
+		bidTx, bundle, err := testutils.CreateAuctionTx(
+			s.encCfg.TxConfig,
+			s.accounts[0],
+			sdk.NewCoin("stake", math.NewInt(100)),
+			0,
+			0,
+			s.accounts[0:2],
+			100,
+		)
+		s.Require().NoError(err)
+
+		otherTx, err := testutils.CreateRandomTx(s.encCfg.TxConfig, s.accounts[0], 0, 1, 0, 100)
+		s.Require().NoError(err)
+
+		partialProposal := []sdk.Tx{bidTx, bundle[0], bundle[1], otherTx}
+
+		lane := s.initLane(math.LegacyOneDec(), map[sdk.Tx]bool{bidTx: true, bundle[0]: true, bundle[1]: true})
+
+		txsFromLane, remainingTxs, err := lane.ProcessLaneHandler()(s.ctx, partialProposal)
+		s.Require().NoError(err)
+		s.Require().Equal(3, len(txsFromLane))
+		s.Require().Equal(1, len(remainingTxs))
+		s.Require().Equal(otherTx, remainingTxs[0])
+
+		proposal := proposals.NewProposal(log.NewNopLogger(), s.encCfg.TxConfig.TxEncoder(), 200000, 1000000)
+		proposal, err = lane.ProcessLane(s.ctx, proposal, partialProposal, block.NoOpProcessLanesHandler())
+		s.Require().NoError(err)
+		s.Require().Len(proposal.Txs, 3)
+
+		encodedTxs, err := utils.GetEncodedTxs(s.encCfg.TxConfig.TxEncoder(), []sdk.Tx{bidTx, bundle[0], bundle[1]})
+		s.Require().NoError(err)
+		s.Require().Equal(encodedTxs, proposal.Txs)
+	})
+
+	s.Run("rejects a block where the bid tx is not the first tx", func() {
+		bidTx, bundle, err := testutils.CreateAuctionTx(
+			s.encCfg.TxConfig,
+			s.accounts[0],
+			sdk.NewCoin("stake", math.NewInt(100)),
+			0,
+			0,
+			s.accounts[0:2],
+			100,
+		)
+		s.Require().NoError(err)
+
+		otherTx, err := testutils.CreateRandomTx(s.encCfg.TxConfig, s.accounts[0], 0, 1, 0, 100)
+		s.Require().NoError(err)
+
+		partialProposal := []sdk.Tx{otherTx, bidTx, bundle[0], bundle[1]}
+
+		lane := s.initLane(math.LegacyOneDec(), map[sdk.Tx]bool{bidTx: true, bundle[0]: true, bundle[1]: true})
+
+		txsFromLane, remainingTxs, err := lane.ProcessLaneHandler()(s.ctx, partialProposal)
+		s.Require().Error(err)
+		s.Require().Equal(0, len(txsFromLane))
+		s.Require().Equal(0, len(remainingTxs))
+
+		proposal := proposals.NewProposal(log.NewNopLogger(), s.encCfg.TxConfig.TxEncoder(), 200000, 1000000)
 		_, err = lane.ProcessLane(s.ctx, proposal, partialProposal, block.NoOpProcessLanesHandler())
 		s.Require().Error(err)
 	})

--- a/lanes/mev/abci_test.go
+++ b/lanes/mev/abci_test.go
@@ -239,14 +239,15 @@ func (s *MEVTestSuite) TestProcessLane() {
 	})
 
 	s.Run("can process a proposal with tx that does not belong to this lane", func() {
-		txBz, err := testutils.CreateRandomTxBz(s.encCfg.TxConfig, s.accounts[0], 0, 1, 0, 100)
+		tx, err := testutils.CreateRandomTx(s.encCfg.TxConfig, s.accounts[0], 0, 1, 0, 100)
 		s.Require().NoError(err)
 
 		lane := s.initLane(math.LegacyOneDec(), nil)
 		proposal := proposals.NewProposal(log.NewNopLogger(), s.encCfg.TxConfig.TxEncoder(), 200, 100)
 
-		_, err = lane.ProcessLane(s.ctx, proposal, [][]byte{txBz}, block.NoOpProcessLanesHandler())
-		s.Require().Error(err)
+		finalProposal, err := lane.ProcessLane(s.ctx, proposal, []sdk.Tx{tx}, block.NoOpProcessLanesHandler())
+		s.Require().NoError(err)
+		s.Require().Equal(0, len(finalProposal.Txs))
 	})
 
 	s.Run("can process a proposal with bad bid tx", func() {
@@ -261,8 +262,7 @@ func (s *MEVTestSuite) TestProcessLane() {
 		)
 		s.Require().NoError(err)
 
-		partialProposal, err := utils.GetEncodedTxs(s.encCfg.TxConfig.TxEncoder(), []sdk.Tx{bidTx})
-		s.Require().NoError(err)
+		partialProposal := []sdk.Tx{bidTx}
 
 		lane := s.initLane(math.LegacyOneDec(), map[sdk.Tx]bool{bidTx: false})
 		proposal := proposals.NewProposal(log.NewNopLogger(), s.encCfg.TxConfig.TxEncoder(), 200000, 1000000)
@@ -283,8 +283,7 @@ func (s *MEVTestSuite) TestProcessLane() {
 		)
 		s.Require().NoError(err)
 
-		partialProposal, err := utils.GetEncodedTxs(s.encCfg.TxConfig.TxEncoder(), []sdk.Tx{bidTx, bundle[0], bundle[1]})
-		s.Require().NoError(err)
+		partialProposal := []sdk.Tx{bidTx, bundle[0], bundle[1]}
 
 		lane := s.initLane(math.LegacyOneDec(), map[sdk.Tx]bool{bidTx: true, bundle[0]: true, bundle[1]: false})
 		proposal := proposals.NewProposal(log.NewNopLogger(), s.encCfg.TxConfig.TxEncoder(), 200000, 1000000)
@@ -305,8 +304,7 @@ func (s *MEVTestSuite) TestProcessLane() {
 		)
 		s.Require().NoError(err)
 
-		partialProposal, err := utils.GetEncodedTxs(s.encCfg.TxConfig.TxEncoder(), []sdk.Tx{bidTx, bundle[1], bundle[0]})
-		s.Require().NoError(err)
+		partialProposal := []sdk.Tx{bidTx, bundle[1], bundle[0]}
 
 		lane := s.initLane(math.LegacyOneDec(), map[sdk.Tx]bool{bidTx: true, bundle[0]: true, bundle[1]: true})
 		proposal := proposals.NewProposal(log.NewNopLogger(), s.encCfg.TxConfig.TxEncoder(), 200000, 1000000)
@@ -327,8 +325,7 @@ func (s *MEVTestSuite) TestProcessLane() {
 		)
 		s.Require().NoError(err)
 
-		partialProposal, err := utils.GetEncodedTxs(s.encCfg.TxConfig.TxEncoder(), []sdk.Tx{bidTx, bundle[0]})
-		s.Require().NoError(err)
+		partialProposal := []sdk.Tx{bidTx, bundle[0]}
 
 		lane := s.initLane(math.LegacyOneDec(), map[sdk.Tx]bool{bidTx: true, bundle[0]: true})
 		proposal := proposals.NewProposal(log.NewNopLogger(), s.encCfg.TxConfig.TxEncoder(), 200000, 1000000)
@@ -349,8 +346,7 @@ func (s *MEVTestSuite) TestProcessLane() {
 		)
 		s.Require().NoError(err)
 
-		partialProposal, err := utils.GetEncodedTxs(s.encCfg.TxConfig.TxEncoder(), []sdk.Tx{bidTx, bundle[0], bundle[1]})
-		s.Require().NoError(err)
+		partialProposal := []sdk.Tx{bidTx, bundle[0], bundle[1]}
 
 		lane := s.initLane(math.LegacyOneDec(), map[sdk.Tx]bool{bidTx: true, bundle[0]: true, bundle[1]: true})
 		proposal := proposals.NewProposal(log.NewNopLogger(), s.encCfg.TxConfig.TxEncoder(), 200000, 1000000)
@@ -371,8 +367,7 @@ func (s *MEVTestSuite) TestProcessLane() {
 		)
 		s.Require().NoError(err)
 
-		partialProposal, err := utils.GetEncodedTxs(s.encCfg.TxConfig.TxEncoder(), []sdk.Tx{bidTx})
-		s.Require().NoError(err)
+		partialProposal := []sdk.Tx{bidTx}
 
 		lane := s.initLane(math.LegacyOneDec(), map[sdk.Tx]bool{bidTx: true})
 		proposal := proposals.NewProposal(log.NewNopLogger(), s.encCfg.TxConfig.TxEncoder(), 200000, 1000000)
@@ -393,8 +388,7 @@ func (s *MEVTestSuite) TestProcessLane() {
 		)
 		s.Require().NoError(err)
 
-		partialProposal, err := utils.GetEncodedTxs(s.encCfg.TxConfig.TxEncoder(), []sdk.Tx{bidTx, bundle[0], bundle[1]})
-		s.Require().NoError(err)
+		partialProposal := []sdk.Tx{bidTx, bundle[0], bundle[1]}
 
 		lane := s.initLane(math.LegacyOneDec(), map[sdk.Tx]bool{bidTx: true, bundle[0]: true, bundle[1]: true})
 		proposal := proposals.NewProposal(log.NewNopLogger(), s.encCfg.TxConfig.TxEncoder(), 20000, 99)
@@ -415,8 +409,7 @@ func (s *MEVTestSuite) TestProcessLane() {
 		)
 		s.Require().NoError(err)
 
-		partialProposal, err := utils.GetEncodedTxs(s.encCfg.TxConfig.TxEncoder(), []sdk.Tx{bidTx, bundle[0], bundle[1]})
-		s.Require().NoError(err)
+		partialProposal := []sdk.Tx{bidTx, bundle[0], bundle[1]}
 
 		lane := s.initLane(math.LegacyOneDec(), map[sdk.Tx]bool{bidTx: true, bundle[0]: true, bundle[1]: true})
 		proposal := proposals.NewProposal(log.NewNopLogger(), s.encCfg.TxConfig.TxEncoder(), 200, 100)

--- a/lanes/terminator/lane.go
+++ b/lanes/terminator/lane.go
@@ -2,6 +2,7 @@ package terminator
 
 import (
 	"context"
+	"fmt"
 
 	"cosmossdk.io/log"
 	"cosmossdk.io/math"
@@ -46,7 +47,11 @@ func (t Terminator) PrepareLane(_ sdk.Context, proposal proposals.Proposal, _ bl
 }
 
 // ProcessLane is a no-op
-func (t Terminator) ProcessLane(_ sdk.Context, p proposals.Proposal, _ [][]byte, _ block.ProcessLanesHandler) (proposals.Proposal, error) {
+func (t Terminator) ProcessLane(_ sdk.Context, p proposals.Proposal, txs []sdk.Tx, _ block.ProcessLanesHandler) (proposals.Proposal, error) {
+	if len(txs) > 0 {
+		return p, fmt.Errorf("terminator lane should not have any transactions")
+	}
+
 	return p, nil
 }
 

--- a/tests/integration/block_sdk_integration_test.go
+++ b/tests/integration/block_sdk_integration_test.go
@@ -64,7 +64,7 @@ var (
 	}
 
 	consensusParams = ictestutil.Toml{
-		"timeout_commit": "3500ms",
+		"timeout_commit": "5000ms",
 	}
 
 	// interchain specification

--- a/tests/integration/block_sdk_suite.go
+++ b/tests/integration/block_sdk_suite.go
@@ -1283,7 +1283,7 @@ func (s *IntegrationTestSuite) TestNetwork() {
 				return
 			default:
 				height, err := s.chain.(*cosmos.CosmosChain).Height(context.Background())
-				require.NoError(s.T(), err)
+				s.NoError(err)
 				WaitForHeight(s.T(), s.chain.(*cosmos.CosmosChain), height+1)
 
 				s.T().Logf("height: %d", height+1)
@@ -1308,7 +1308,7 @@ func (s *IntegrationTestSuite) TestNetwork() {
 				return
 			default:
 				height, err := s.chain.(*cosmos.CosmosChain).Height(context.Background())
-				require.NoError(s.T(), err)
+				s.NoError(err)
 				WaitForHeight(s.T(), s.chain.(*cosmos.CosmosChain), height+1)
 
 				s.T().Logf("height: %d", height+1)
@@ -1332,7 +1332,7 @@ func (s *IntegrationTestSuite) TestNetwork() {
 				return
 			default:
 				height, err := s.chain.(*cosmos.CosmosChain).Height(context.Background())
-				require.NoError(s.T(), err)
+				s.NoError(err)
 				WaitForHeight(s.T(), s.chain.(*cosmos.CosmosChain), height+1)
 
 				s.T().Logf("height: %d", height+1)
@@ -1362,7 +1362,7 @@ func (s *IntegrationTestSuite) TestNetwork() {
 				return
 			default:
 				height, err := s.chain.(*cosmos.CosmosChain).Height(context.Background())
-				require.NoError(s.T(), err)
+				s.NoError(err)
 				WaitForHeight(s.T(), s.chain.(*cosmos.CosmosChain), height+1)
 
 				s.T().Logf("height: %d", height+1)
@@ -1416,7 +1416,7 @@ func (s *IntegrationTestSuite) TestNetwork() {
 				return
 			default:
 				height, err := s.chain.(*cosmos.CosmosChain).Height(context.Background())
-				require.NoError(s.T(), err)
+				s.NoError(err)
 				WaitForHeight(s.T(), s.chain.(*cosmos.CosmosChain), height+1)
 
 				s.T().Logf("height: %d", height+1)

--- a/tests/integration/chain_setup.go
+++ b/tests/integration/chain_setup.go
@@ -356,25 +356,11 @@ func WaitForHeight(t *testing.T, chain *cosmos.CosmosChain, height uint64) {
 	require.NoError(t, err)
 }
 
-// VerifyBlock takes a Block and verifies that it contains the given bid at the 0-th index, and the bundled txs immediately after
-func VerifyBlock(t *testing.T, block *rpctypes.ResultBlock, offset int, bidTxHash string, txs [][]byte) {
-	// verify the block
-	if bidTxHash != "" {
-		require.Equal(t, bidTxHash, TxHash(block.Block.Data.Txs[offset+1]))
-		offset += 1
-	}
-
-	// verify the txs in sequence
-	for i, tx := range txs {
-		require.Equal(t, TxHash(tx), TxHash(block.Block.Data.Txs[i+offset+1]))
-	}
-}
-
 // VerifyBlockWithExpectedBlock takes in a list of raw tx bytes and compares each tx hash to the tx hashes in the block.
 // The expected block is the block that should be returned by the chain at the given height.
 func VerifyBlockWithExpectedBlock(t *testing.T, chain *cosmos.CosmosChain, height uint64, txs [][]byte) {
 	block := Block(t, chain, int64(height))
-	blockTxs := block.Block.Data.Txs[1:]
+	blockTxs := block.Block.Data.Txs
 
 	t.Logf("verifying block %d", height)
 	require.Equal(t, len(txs), len(blockTxs))

--- a/tests/integration/chain_setup.go
+++ b/tests/integration/chain_setup.go
@@ -24,6 +24,7 @@ import (
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	interchaintest "github.com/strangelove-ventures/interchaintest/v8"
 	"github.com/strangelove-ventures/interchaintest/v8/chain/cosmos"
@@ -124,6 +125,71 @@ func (s *IntegrationTestSuite) CreateTx(ctx context.Context, chain *cosmos.Cosmo
 	return bz
 }
 
+func (s *IntegrationTestSuite) CreateDummyAuctionBidTx(
+	height uint64,
+	searcher ibc.Wallet,
+	bid sdk.Coin,
+) Tx {
+	msgAuctionBid := auctiontypes.NewMsgAuctionBid(
+		searcher.Address(),
+		bid,
+		nil,
+	)
+
+	return Tx{
+		User:               searcher,
+		Msgs:               []sdk.Msg{msgAuctionBid},
+		GasPrice:           1000,
+		Height:             height + 1,
+		SkipInclusionCheck: true,
+		IgnoreChecks:       true,
+	}
+}
+
+func (s *IntegrationTestSuite) CreateDummyNormalTx(
+	from, to ibc.Wallet,
+	coins sdk.Coins,
+	sequenceOffset uint64,
+	gasPrice int64,
+) Tx {
+	msgSend := banktypes.NewMsgSend(
+		sdk.AccAddress(from.Address()),
+		sdk.AccAddress(to.Address()),
+		coins,
+	)
+
+	return Tx{
+		User:               from,
+		Msgs:               []sdk.Msg{msgSend},
+		GasPrice:           gasPrice,
+		SequenceIncrement:  sequenceOffset,
+		SkipInclusionCheck: true,
+		IgnoreChecks:       true,
+	}
+}
+
+func (s *IntegrationTestSuite) CreateDummyFreeTx(
+	user ibc.Wallet,
+	validator sdk.ValAddress,
+	delegation sdk.Coin,
+	sequenceOffset uint64,
+) Tx {
+	delegateMsg := stakingtypes.NewMsgDelegate(
+		sdk.AccAddress(user.Address()).String(),
+		sdk.ValAddress(validator).String(),
+		delegation,
+	)
+
+	return Tx{
+		User:               user,
+		Msgs:               []sdk.Msg{delegateMsg},
+		GasPrice:           1000,
+		SequenceIncrement:  sequenceOffset,
+		SkipInclusionCheck: true,
+		IgnoreChecks:       true,
+	}
+}
+
 // SimulateTx simulates the provided messages, and checks whether the provided failure condition is met
 func (s *IntegrationTestSuite) SimulateTx(ctx context.Context, chain *cosmos.CosmosChain, user cosmos.User, height uint64, expectFail bool, msgs ...sdk.Msg) {
 	// create tx factory + Client Context
@@ -154,6 +220,7 @@ type Tx struct {
 	Height             uint64
 	SkipInclusionCheck bool
 	ExpectFail         bool
+	IgnoreChecks       bool
 }
 
 // CreateAuctionBidMsg creates a new AuctionBid tx signed by the given user, the order of txs in the MsgAuctionBid will be determined by the contents + order of the MessageForUsers
@@ -203,13 +270,13 @@ func (s *IntegrationTestSuite) BroadcastTxsWithCallback(
 	s.Require().True(len(chain.Nodes()) > 0)
 	client := chain.Nodes()[0].Client
 
-	statusResp, err := client.Status(context.Background())
-	s.Require().NoError(err)
-
-	s.T().Logf("broadcasting transactions at latest height of %d", statusResp.SyncInfo.LatestBlockHeight)
-
 	for i, tx := range rawTxs {
 		// broadcast tx
+		if txs[i].IgnoreChecks {
+			client.BroadcastTxAsync(ctx, tx)
+			continue
+		}
+
 		resp, err := client.BroadcastTxSync(ctx, tx)
 
 		// check execution was successful
@@ -228,7 +295,7 @@ func (s *IntegrationTestSuite) BroadcastTxsWithCallback(
 	eg := errgroup.Group{}
 	for i, tx := range rawTxs {
 		// if we don't expect this tx to be included.. skip it
-		if txs[i].SkipInclusionCheck || txs[i].ExpectFail {
+		if txs[i].SkipInclusionCheck || txs[i].ExpectFail || txs[i].IgnoreChecks {
 			continue
 		}
 


### PR DESCRIPTION
## Overview

Currently we give network operators a view into the structure of a block proposal by including a `MetaData` transaction in the first slot of the proposal - `ProposalInfoIndex`. This `MetaData` includes the number of transactions by lane, total gas consumption, and more.  This information is utilized to break apart the proposal into partial proposals where each lane can then verify each partial proposal to its own verification logic, respecting the ordering of lanes as defined by the protocol.

However, this has several disadvantages including:
1. Every block will include a failed transaction.
2. It's not immediately clear if it is safe to include a transaction in a proposal that will predictably cannot be unmarshalled to a `sdk.Tx` in the life cycle of building and committing a block.

To that we introduce a **Greedy Proposal Verification** which allows lanes to determine what transactions belong to them at runtime i.e. when a request to verify a proposal is initiated.

### Greedy Proposal Verification

The algorithm is fairly simple and does the following in a repeated manner for each lane. Given a lane **X**,
1. If the first transaction belongs to this lane, verify it and proceed to step 3. Otherwise go to step 2.
2. If the transaction does not belong to this lane, no other transactions later in the proposal can be matched to this lane. Otherwise, transactions belonging to different lanes are interleaved with each other. If no transaction later in the proposal matches to this lane, return the remaining transactions to the next lane in the chain of lanes.
3. Reduce the size of the proposal by 1, i.e. `proposal = proposal[1:]` and go to step 1.


### Related Issue

This fix will close this issue https://github.com/skip-mev/block-sdk/issues/215.