### PR TITLE
chore: Get goreleaser working for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
   push:
     # Sequence of patterns matched against refs/tags
     tags:
-      - "v[0-9]+.[0-9]+.[0-9]+" # Push events to matching v*, i.e. v1.0, v20.15.10
+      - "v[0-9]+.*" # Push events to matching v0.*, v1.*, etc., i.e. v1.0, v2.15.10, v1.2.3-beta.0
 
 permissions:
   contents: read
@@ -26,6 +26,6 @@ jobs:
       - name: Create release
         uses: goreleaser/goreleaser-action@v5
         with:
-          args: release --rm-dist --release-notes ./RELEASE_NOTES.md
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -32,3 +32,5 @@ checksum:
 
 source:
   enabled: true
+  files:
+    - **/*

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,3 +29,6 @@ changelog:
 
 checksum:
   disable: false
+
+source:
+  enabled: true

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,6 +5,7 @@ release:
   github:
     owner: skip-mev
     name: block-sdk
+  prerelease: true
 
 builds:
   - skip: true
@@ -24,3 +25,7 @@ snapshot:
 
 changelog:
   skip: false
+  use: 'github'
+
+checksum:
+  disable: false

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -32,5 +32,3 @@ checksum:
 
 source:
   enabled: true
-  files:
-    - '**/*'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -33,4 +33,4 @@ checksum:
 source:
   enabled: true
   files:
-    - **/*
+    - '**/*'


### PR DESCRIPTION
Fixes up the goreleaser workflow to make it build releases on tag pushes.

This should backport to any branch we want to support--so `v1.x.x` or `v2.x.x`.
Since this is a library it just packages up the source code and publishes a checksum.

Corresponding build that succeeded https://github.com/skip-mev/block-sdk/actions/runs/7174966354 (I've deleted the test release created by this).