### PR TITLE
refactor(tests): use grpc instead of cli for all network testing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/gorilla/mux v1.8.1
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
 	github.com/huandu/skiplist v1.2.0
-	github.com/skip-mev/chaintestutil v0.0.0-20231212161650-5a0fb41c56cc
+	github.com/skip-mev/chaintestutil v0.0.0-20231213172849-7c623445dde1
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.17.0

--- a/go.sum
+++ b/go.sum
@@ -1223,8 +1223,8 @@ github.com/sivchari/nosnakecase v1.7.0 h1:7QkpWIRMe8x25gckkFd2A5Pi6Ymo0qgr4JrhGt
 github.com/sivchari/nosnakecase v1.7.0/go.mod h1:CwDzrzPea40/GB6uynrNLiorAlgFRvRbFSgJx2Gs+QY=
 github.com/sivchari/tenv v1.7.1 h1:PSpuD4bu6fSmtWMxSGWcvqUUgIn7k3yOJhOIzVWn8Ak=
 github.com/sivchari/tenv v1.7.1/go.mod h1:64yStXKSOxDfX47NlhVwND4dHwfZDdbp2Lyl018Icvg=
-github.com/skip-mev/chaintestutil v0.0.0-20231212161650-5a0fb41c56cc h1:raXVdBCZVt9HV8nA7yspL4rVswLtCxV40cTjEviaKgM=
-github.com/skip-mev/chaintestutil v0.0.0-20231212161650-5a0fb41c56cc/go.mod h1:mcyq67cXQTzyhCg2LSBeFS+u7GzWng5xnTFfUAqIHn4=
+github.com/skip-mev/chaintestutil v0.0.0-20231213172849-7c623445dde1 h1:x1hie4oqAp0Ay0ijolPKaKVFAHXKuMulBir2RGe1oc0=
+github.com/skip-mev/chaintestutil v0.0.0-20231213172849-7c623445dde1/go.mod h1:mcyq67cXQTzyhCg2LSBeFS+u7GzWng5xnTFfUAqIHn4=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=

--- a/tests/integration/network_test.go
+++ b/tests/integration/network_test.go
@@ -1,19 +1,17 @@
 package integration_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
 	tmcli "github.com/cometbft/cometbft/libs/cli"
-	clitestutil "github.com/cosmos/cosmos-sdk/testutil/cli"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/grpc/status"
 
 	"github.com/skip-mev/block-sdk/testutils/networksuite"
-	auctioncli "github.com/skip-mev/block-sdk/x/auction/client/cli"
 	auctiontypes "github.com/skip-mev/block-sdk/x/auction/types"
-	blocksdkcli "github.com/skip-mev/block-sdk/x/blocksdk/client/cli"
 	blocksdktypes "github.com/skip-mev/block-sdk/x/blocksdk/types"
 )
 
@@ -29,8 +27,6 @@ func TestNetworkTestSuite(t *testing.T) {
 
 func (s *NetworkTestSuite) TestGetLanes() {
 	s.T().Parallel()
-
-	val := s.Network.Validators[0]
 
 	common := []string{
 		fmt.Sprintf("--%s=json", tmcli.OutputFlag),
@@ -50,15 +46,13 @@ func (s *NetworkTestSuite) TestGetLanes() {
 	} {
 		s.T().Run(tc.name, func(t *testing.T) {
 			tc := tc
-			out, err := clitestutil.ExecTestCLICmd(val.ClientCtx, blocksdkcli.CmdQueryLanes(), tc.args)
+			resp, err := s.QueryBlockSDKLanes()
 			if tc.err != nil {
 				stat, ok := status.FromError(tc.err)
 				require.True(t, ok)
 				require.ErrorIs(t, stat.Err(), tc.err)
 			} else {
 				require.NoError(t, err)
-				var resp blocksdktypes.QueryLanesResponse
-				require.NoError(t, s.Network.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
 				require.NotNil(t, resp.Lanes)
 				require.ElementsMatch(t, tc.obj, resp.Lanes)
 			}
@@ -68,8 +62,6 @@ func (s *NetworkTestSuite) TestGetLanes() {
 
 func (s *NetworkTestSuite) TestGetAuctionParams() {
 	s.T().Parallel()
-
-	val := s.Network.Validators[0]
 
 	common := []string{
 		fmt.Sprintf("--%s=json", tmcli.OutputFlag),
@@ -89,18 +81,38 @@ func (s *NetworkTestSuite) TestGetAuctionParams() {
 	} {
 		s.T().Run(tc.name, func(t *testing.T) {
 			tc := tc
-			out, err := clitestutil.ExecTestCLICmd(val.ClientCtx, auctioncli.CmdQueryParams(), tc.args)
+			resp, err := s.QueryAuctionParams()
 			if tc.err != nil {
 				stat, ok := status.FromError(tc.err)
 				require.True(t, ok)
 				require.ErrorIs(t, stat.Err(), tc.err)
 			} else {
 				require.NoError(t, err)
-				var resp auctiontypes.QueryParamsResponse
-				require.NoError(t, s.Network.Config.Codec.UnmarshalJSON(out.Bytes(), &resp.Params))
 				require.NotNil(t, resp)
 				require.Equal(t, tc.obj, resp.Params)
 			}
 		})
 	}
+}
+
+func (s *NetworkTestSuite) QueryAuctionParams() (*auctiontypes.QueryParamsResponse, error) {
+	s.T().Helper()
+
+	cc, closeConn, err := s.NetworkSuite.GetGRPC()
+	s.Require().NoError(err)
+	defer closeConn()
+
+	client := auctiontypes.NewQueryClient(cc)
+	return client.Params(context.Background(), &auctiontypes.QueryParamsRequest{})
+}
+
+func (s *NetworkTestSuite) QueryBlockSDKLanes() (*blocksdktypes.QueryLanesResponse, error) {
+	s.T().Helper()
+
+	cc, closeConn, err := s.NetworkSuite.GetGRPC()
+	s.Require().NoError(err)
+	defer closeConn()
+
+	client := blocksdktypes.NewQueryClient(cc)
+	return client.Lanes(context.Background(), &blocksdktypes.QueryLanesRequest{})
 }

--- a/testutils/networksuite/networksuite.go
+++ b/testutils/networksuite/networksuite.go
@@ -19,11 +19,11 @@ import (
 	blocksdktypes "github.com/skip-mev/block-sdk/x/blocksdk/types"
 )
 
-// NetworkTestSuite is a test suite for query tests that initializes a network instance.
+// NetworkTestSuite is a test suite for tests that initializes a network instance.
 type NetworkTestSuite struct {
 	suite.Suite
 
-	Network       *network.Network
+	NetworkSuite  *network.TestSuite
 	AuctionState  auctiontypes.GenesisState
 	BlockSDKState blocksdktypes.GenesisState
 }
@@ -49,7 +49,7 @@ func (nts *NetworkTestSuite) SetupSuite() {
 	nts.BlockSDKState = populateBlockSDK(r, nts.BlockSDKState)
 	updateGenesisConfigState(blocksdktypes.ModuleName, &nts.BlockSDKState)
 
-	nts.Network = network.New(nts.T(), cfg)
+	nts.NetworkSuite = network.NewSuite(nts.T(), cfg)
 }
 
 func populateAuction(_ *rand.Rand, auctionState auctiontypes.GenesisState) auctiontypes.GenesisState {


### PR DESCRIPTION
- replace CLI usages with much simpler GRPC calls to the 1st validator node