### PR TITLE
test: Update networksuite with testapp builder

### DIFF
--- a/testutils/networksuite/networksuite.go
+++ b/testutils/networksuite/networksuite.go
@@ -2,7 +2,14 @@
 package networksuite
 
 import (
+	"cosmossdk.io/log"
+	pruningtypes "cosmossdk.io/store/pruning/types"
+	dbm "github.com/cosmos/cosmos-db"
+	"github.com/cosmos/cosmos-sdk/baseapp"
+	servertypes "github.com/cosmos/cosmos-sdk/server/types"
+	simtestutil "github.com/cosmos/cosmos-sdk/testutil/sims"
 	"math/rand"
+	"os"
 
 	"cosmossdk.io/math"
 	"github.com/cosmos/gogoproto/proto"
@@ -31,9 +38,22 @@ type NetworkTestSuite struct {
 // SetupSuite setups the local network with a genesis state.
 func (nts *NetworkTestSuite) SetupSuite() {
 	var (
-		r   = sample.Rand()
-		cfg = network.NewConfig(app.AppConfig)
+		r       = sample.Rand()
+		cfg     = network.NewConfig(app.AppConfig)
+		appCons = func(val network.ValidatorI) servertypes.Application {
+			return app.New(
+				log.NewLogger(os.Stdout),
+				dbm.NewMemDB(),
+				nil,
+				true,
+				simtestutil.NewAppOptionsWithFlagHome(val.GetCtx().Config.RootDir),
+				baseapp.SetPruning(pruningtypes.NewPruningOptionsFromString(val.GetAppConfig().Pruning)),
+				baseapp.SetMinGasPrices(val.GetAppConfig().MinGasPrices),
+				baseapp.SetChainID(cfg.ChainID),
+			)
+		}
 	)
+	cfg.AppConstructor = appCons
 
 	updateGenesisConfigState := func(moduleName string, moduleState proto.Message) {
 		buf, err := cfg.Codec.MarshalJSON(moduleState)

--- a/testutils/networksuite/networksuite.go
+++ b/testutils/networksuite/networksuite.go
@@ -2,14 +2,15 @@
 package networksuite
 
 import (
+	"math/rand"
+	"os"
+
 	"cosmossdk.io/log"
 	pruningtypes "cosmossdk.io/store/pruning/types"
 	dbm "github.com/cosmos/cosmos-db"
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
 	simtestutil "github.com/cosmos/cosmos-sdk/testutil/sims"
-	"math/rand"
-	"os"
 
 	"cosmossdk.io/math"
 	"github.com/cosmos/gogoproto/proto"


### PR DESCRIPTION
Updates the network suite to actually launch our testapp--it also logs to stdout which can be quite noisy, but it's only a single node and makes debugging a lot easier.

