### PR TITLE
feat: Remove tx order verification from mempool [BLO-763]

### DIFF
--- a/abci/abci_test.go
+++ b/abci/abci_test.go
@@ -14,7 +14,9 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/skip-mev/block-sdk/abci"
+	signerextraction "github.com/skip-mev/block-sdk/adapters/signer_extraction_adapter"
 	"github.com/skip-mev/block-sdk/block"
+	"github.com/skip-mev/block-sdk/block/base"
 	"github.com/skip-mev/block-sdk/block/mocks"
 	"github.com/skip-mev/block-sdk/lanes/free"
 	testutils "github.com/skip-mev/block-sdk/testutils"
@@ -1072,7 +1074,7 @@ func (s *ProposalsTestSuite) TestProcessProposal() {
 		s.Require().Equal(&cometabci.ResponseProcessProposal{Status: cometabci.ResponseProcessProposal_REJECT}, resp)
 	})
 
-	s.Run("can process a invalid proposal (default lane out of order)", func() {
+	s.Run("can process an invalid proposal with txs out of order", func() {
 		// Create a random transaction that will be inserted into the default lane
 		tx1, err := testutils.CreateRandomTx(
 			s.encodingConfig.TxConfig,
@@ -1101,7 +1103,10 @@ func (s *ProposalsTestSuite) TestProcessProposal() {
 		mevLane := s.setUpTOBLane(math.LegacyMustNewDecFromStr("0.3"), map[sdk.Tx]bool{})
 
 		// Set up the default lane
-		defaultLane := s.setUpStandardLane(math.LegacyMustNewDecFromStr("0.0"), map[sdk.Tx]bool{tx2: true, tx1: true})
+		defaultLane := s.setUpStandardLaneWithComparator(math.LegacyMustNewDecFromStr("0.0"), map[sdk.Tx]bool{tx2: true, tx1: true}, base.PriorityNonceComparator(
+			signerextraction.NewDefaultAdapter(),
+			base.DefaultTxPriority(),
+		))
 
 		proposal := s.createProposal(tx2, tx1)
 
@@ -1357,27 +1362,35 @@ func (s *ProposalsTestSuite) TestPrepareProcessParity() {
 	// Create a bunch of transactions to insert into the default lane
 	txsToInsert := []sdk.Tx{}
 	validationMap := make(map[sdk.Tx]bool)
-	for _, account := range accounts {
-		for nonce := uint64(0); nonce < numTxsPerAccount; nonce++ {
-			mod := nonce % uint64(len(feeDenoms))
-			feeDenom := feeDenoms[mod]
-
-			// create a random fee amount
-			feeAmount := math.NewInt(int64(rand.Intn(100000)))
-			tx, err := testutils.CreateRandomTx(
-				s.encodingConfig.TxConfig,
-				account,
-				nonce,
-				1,
-				0,
-				1,
-				sdk.NewCoin(feeDenom, feeAmount),
-			)
-			s.Require().NoError(err)
-
-			txsToInsert = append(txsToInsert, tx)
-			validationMap[tx] = true
+	for nonce := uint64(0); nonce < numTxsPerAccount * uint64(numAccounts); nonce++ {
+		fees := []sdk.Coin{}
+		// choose a random set of fee denoms
+		perm := rand.Perm(len(feeDenoms))
+		for i := 0; i < 1 + rand.Intn(len(feeDenoms) - 1); i++ {
+			fees = append(fees, sdk.NewCoin(feeDenoms[perm[i]], math.NewInt(int64(rand.Intn(100000)))))
 		}
+
+		// choose a random set of accounts
+		perm = rand.Perm(len(accounts))
+		signers := []testutils.Account{}
+		for i := 0; i < 1 + rand.Intn(len(accounts) - 1); i++ {
+			signers = append(signers, accounts[perm[i]])
+		}
+
+		// create a random fee amount
+		tx, err := testutils.CreateRandomTxMultipleSigners(
+			s.encodingConfig.TxConfig,
+			signers,
+			nonce,
+			1,
+			0,
+			1,
+			fees...,
+		)
+		s.Require().NoError(err)
+
+		txsToInsert = append(txsToInsert, tx)
+		validationMap[tx] = true
 	}
 
 	// Set up the default lane with the transactions

--- a/abci/abci_test.go
+++ b/abci/abci_test.go
@@ -1362,18 +1362,18 @@ func (s *ProposalsTestSuite) TestPrepareProcessParity() {
 	// Create a bunch of transactions to insert into the default lane
 	txsToInsert := []sdk.Tx{}
 	validationMap := make(map[sdk.Tx]bool)
-	for nonce := uint64(0); nonce < numTxsPerAccount * uint64(numAccounts); nonce++ {
+	for nonce := uint64(0); nonce < numTxsPerAccount*uint64(numAccounts); nonce++ {
 		fees := []sdk.Coin{}
 		// choose a random set of fee denoms
 		perm := rand.Perm(len(feeDenoms))
-		for i := 0; i < 1 + rand.Intn(len(feeDenoms) - 1); i++ {
+		for i := 0; i < 1+rand.Intn(len(feeDenoms)-1); i++ {
 			fees = append(fees, sdk.NewCoin(feeDenoms[perm[i]], math.NewInt(int64(rand.Intn(100000)))))
 		}
 
 		// choose a random set of accounts
 		perm = rand.Perm(len(accounts))
 		signers := []testutils.Account{}
-		for i := 0; i < 1 + rand.Intn(len(accounts) - 1); i++ {
+		for i := 0; i < 1+rand.Intn(len(accounts)-1); i++ {
 			signers = append(signers, accounts[perm[i]])
 		}
 

--- a/abci/abci_test.go
+++ b/abci/abci_test.go
@@ -1346,11 +1346,22 @@ func (s *ProposalsTestSuite) TestPrepareProcessParity() {
 	numAccounts := 25
 	accounts := testutils.RandomAccounts(s.random, numAccounts)
 
+	feeDenoms := []string{
+		s.gasTokenDenom,
+		"eth",
+		"btc",
+		"usdt",
+		"usdc",
+	}
+
 	// Create a bunch of transactions to insert into the default lane
 	txsToInsert := []sdk.Tx{}
 	validationMap := make(map[sdk.Tx]bool)
 	for _, account := range accounts {
 		for nonce := uint64(0); nonce < numTxsPerAccount; nonce++ {
+			mod := nonce % uint64(len(feeDenoms))
+			feeDenom := feeDenoms[mod]
+
 			// create a random fee amount
 			feeAmount := math.NewInt(int64(rand.Intn(100000)))
 			tx, err := testutils.CreateRandomTx(
@@ -1360,7 +1371,7 @@ func (s *ProposalsTestSuite) TestPrepareProcessParity() {
 				1,
 				0,
 				1,
-				sdk.NewCoin(s.gasTokenDenom, feeAmount),
+				sdk.NewCoin(feeDenom, feeAmount),
 			)
 			s.Require().NoError(err)
 

--- a/abci/utils_test.go
+++ b/abci/utils_test.go
@@ -67,7 +67,7 @@ func (s *ProposalsTestSuite) setUpCustomMatchHandlerLane(maxBlockSpace math.Lega
 
 	options := []base.LaneOption{
 		base.WithMatchHandler(mh),
-		base.WithMempoolConfigs[string](cfg, base.DefaultTxPriority()),
+		base.WithMempoolConfigs[string](cfg, base.DefaultTxPriority(), base.PriorityNonceComparator(signeradaptors.NewDefaultAdapter(), base.DefaultTxPriority())),
 	}
 
 	lane, err := base.NewBaseLane(
@@ -81,6 +81,10 @@ func (s *ProposalsTestSuite) setUpCustomMatchHandlerLane(maxBlockSpace math.Lega
 }
 
 func (s *ProposalsTestSuite) setUpStandardLane(maxBlockSpace math.LegacyDec, expectedExecution map[sdk.Tx]bool) *base.BaseLane {
+	return s.setUpStandardLaneWithComparator(maxBlockSpace, expectedExecution, base.NoopComparator())
+}
+
+func (s *ProposalsTestSuite) setUpStandardLaneWithComparator(maxBlockSpace math.LegacyDec, expectedExecution map[sdk.Tx]bool, comparator base.Comparator) *base.BaseLane {
 	cfg := base.LaneConfig{
 		Logger:          log.NewNopLogger(),
 		TxEncoder:       s.encodingConfig.TxConfig.TxEncoder(),
@@ -90,7 +94,14 @@ func (s *ProposalsTestSuite) setUpStandardLane(maxBlockSpace math.LegacyDec, exp
 		SignerExtractor: signeradaptors.NewDefaultAdapter(),
 	}
 
-	return defaultlane.NewDefaultLane(cfg, base.DefaultMatchHandler())
+	lane := defaultlane.NewDefaultLane(cfg, base.DefaultMatchHandler())
+	lane.WithOptions(base.WithMempoolConfigs(
+		cfg,
+		base.DefaultTxPriority(),
+		comparator,
+	))
+
+	return lane
 }
 
 func (s *ProposalsTestSuite) setUpTOBLane(maxBlockSpace math.LegacyDec, expectedExecution map[sdk.Tx]bool) *mev.MEVLane {
@@ -131,7 +142,7 @@ func (s *ProposalsTestSuite) setUpPanicLane(name string, maxBlockSpace math.Lega
 
 	options := []base.LaneOption{
 		base.WithMatchHandler(base.DefaultMatchHandler()),
-		base.WithMempoolConfigs[string](cfg, base.DefaultTxPriority()),
+		base.WithMempoolConfigs[string](cfg, base.DefaultTxPriority(), base.PriorityNonceComparator(signeradaptors.NewDefaultAdapter(), base.DefaultTxPriority())),
 		base.WithPrepareLaneHandler(base.PanicPrepareLaneHandler()),
 		base.WithProcessLaneHandler(base.PanicProcessLaneHandler()),
 	}

--- a/block/base/lane.go
+++ b/block/base/lane.go
@@ -61,6 +61,7 @@ func NewBaseLane(
 		DefaultTxPriority(),
 		lane.cfg.TxEncoder,
 		lane.cfg.SignerExtractor,
+		NoopComparator(), // default comparison function is NoopComparator
 		lane.cfg.MaxTxs,
 	)
 

--- a/block/base/mempool.go
+++ b/block/base/mempool.go
@@ -45,16 +45,16 @@ type (
 	}
 
 	// Comparator is a comparison function that the mempool uses to verify the ordering of txs. That is,
-	// if this > other (return 1, nil), then this will be ordered before other. Conversely, if this < other, 
+	// if this > other (return 1, nil), then this will be ordered before other. Conversely, if this < other,
 	// this will be ordered after other.
 	Comparator func(ctx sdk.Context, this, other sdk.Tx) (int, error)
 )
 
 // NewMempool returns a new Mempool.
 func NewMempool[C comparable](
-	txPriority TxPriority[C], 
-	txEncoder sdk.TxEncoder, 
-	extractor signer_extraction.Adapter, 
+	txPriority TxPriority[C],
+	txEncoder sdk.TxEncoder,
+	extractor signer_extraction.Adapter,
 	comparator Comparator,
 	maxTx int,
 ) *Mempool[C] {
@@ -159,7 +159,7 @@ func PriorityNonceComparator(extractor signer_extraction.Adapter, txPriority TxP
 		}
 		// The priority nonce mempool uses the first tx signer so this is a safe operation.
 		thisSignerInfo := signers[0]
-	
+
 		signers, err = extractor.GetSigners(other)
 		if err != nil {
 			return 0, err
@@ -168,7 +168,7 @@ func PriorityNonceComparator(extractor signer_extraction.Adapter, txPriority TxP
 			return 0, fmt.Errorf("expected one signer for the second transaction")
 		}
 		otherSignerInfo := signers[0]
-	
+
 		// If the signers are the same, we compare the sequence numbers.
 		if thisSignerInfo.Signer.Equals(otherSignerInfo.Signer) {
 			switch {
@@ -181,7 +181,7 @@ func PriorityNonceComparator(extractor signer_extraction.Adapter, txPriority TxP
 				return 0, fmt.Errorf("the two transactions have the same sequence number")
 			}
 		}
-	
+
 		// Determine the priority and compare the priorities.
 		firstPriority := txPriority.GetTxPriority(ctx, this)
 		secondPriority := txPriority.GetTxPriority(ctx, other)

--- a/block/base/mempool.go
+++ b/block/base/mempool.go
@@ -140,7 +140,7 @@ func (cm *Mempool[C]) Compare(ctx sdk.Context, this, other sdk.Tx) (int, error) 
 	return cm.comparator(ctx, this, other)
 }
 
-// PriorityNonceComparator returns a Comparator that determines the relative priority of two 
+// PriorityNonceComparator returns a Comparator that determines the relative priority of two
 // transactions belonging in the same lane. There are two cases to consider:
 //  1. The transactions have the same signer. In this case, we compare the sequence numbers.
 //  2. The transactions have different signers. In this case, we compare the priorities of the

--- a/block/base/mempool.go
+++ b/block/base/mempool.go
@@ -140,8 +140,8 @@ func (cm *Mempool[C]) Compare(ctx sdk.Context, this, other sdk.Tx) (int, error) 
 	return cm.comparator(ctx, this, other)
 }
 
-// ComparePriorityNonce determines the relative priority of two transactions belonging in the same lane.
-// There are two cases to consider:
+// PriorityNonceComparator returns a Comparator that determines the relative priority of two 
+// transactions belonging in the same lane. There are two cases to consider:
 //  1. The transactions have the same signer. In this case, we compare the sequence numbers.
 //  2. The transactions have different signers. In this case, we compare the priorities of the
 //     transactions.
@@ -190,7 +190,7 @@ func PriorityNonceComparator(extractor signer_extraction.Adapter, txPriority TxP
 }
 
 // NoopComparator is a comparison function that performs no comparison between this and other. In other words,
-// this Comparator returns 1, nil for any set of txs
+// this Comparator returns 1, nil for any set of txs. This is the default Comparator used in the Base, MEV, Free lanes.
 func NoopComparator() Comparator {
 	return func(ctx sdk.Context, this, other sdk.Tx) (int, error) {
 		return 1, nil

--- a/block/base/mempool_test.go
+++ b/block/base/mempool_test.go
@@ -21,6 +21,7 @@ func TestMempoolComparison(t *testing.T) {
 		DefaultTxPriority(),
 		txc.TxEncoder(),
 		signerextraction.NewDefaultAdapter(),
+		PriorityNonceComparator(signerextraction.NewDefaultAdapter(), DefaultTxPriority()),
 		1000,
 	)
 	t.Run("test same account, same nonce", func(t *testing.T) {

--- a/block/base/options.go
+++ b/block/base/options.go
@@ -80,4 +80,3 @@ func WithMempoolConfigs[C comparable](cfg LaneConfig, txPriority TxPriority[C], 
 		)
 	}
 }
-

--- a/block/base/options.go
+++ b/block/base/options.go
@@ -69,13 +69,15 @@ func WithMempool(mempool block.LaneMempool) LaneOption {
 // WithMempoolConfigs sets the mempool for the lane with the given lane config
 // and TxPriority struct. This mempool is used to store transactions that are waiting
 // to be processed.
-func WithMempoolConfigs[C comparable](cfg LaneConfig, txPriority TxPriority[C]) LaneOption {
+func WithMempoolConfigs[C comparable](cfg LaneConfig, txPriority TxPriority[C], comparator Comparator) LaneOption {
 	return func(l *BaseLane) {
 		l.LaneMempool = NewMempool(
 			txPriority,
 			cfg.TxEncoder,
 			cfg.SignerExtractor,
+			comparator,
 			cfg.MaxTxs,
 		)
 	}
 }
+

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/skip-mev/block-sdk
 
-go 1.21.5
+go 1.21.4
+
+toolchain go1.21.6
 
 require (
 	cosmossdk.io/api v0.7.2

--- a/lanes/base/mempool_test.go
+++ b/lanes/base/mempool_test.go
@@ -128,10 +128,10 @@ func (s *BaseTestSuite) TestCompareTxPriorityPriorityNonce() {
 
 func (s *BaseTestSuite) TestInsert() {
 	mempool := base.NewMempool[string](
-		base.DefaultTxPriority(), 
-		s.encodingConfig.TxConfig.TxEncoder(), 
-		signer_extraction.NewDefaultAdapter(), 
-		base.NoopComparator(), 
+		base.DefaultTxPriority(),
+		s.encodingConfig.TxConfig.TxEncoder(),
+		signer_extraction.NewDefaultAdapter(),
+		base.NoopComparator(),
 		3,
 	)
 
@@ -189,9 +189,9 @@ func (s *BaseTestSuite) TestInsert() {
 
 func (s *BaseTestSuite) TestRemove() {
 	mempool := base.NewMempool[string](
-		base.DefaultTxPriority(), 
-		s.encodingConfig.TxConfig.TxEncoder(), 
-		signer_extraction.NewDefaultAdapter(), 
+		base.DefaultTxPriority(),
+		s.encodingConfig.TxConfig.TxEncoder(),
+		signer_extraction.NewDefaultAdapter(),
 		base.NoopComparator(),
 		3,
 	)
@@ -235,10 +235,10 @@ func (s *BaseTestSuite) TestRemove() {
 func (s *BaseTestSuite) TestSelect() {
 	s.Run("should be able to select transactions in the correct order", func() {
 		mempool := base.NewMempool[string](
-			base.DefaultTxPriority(), 
-			s.encodingConfig.TxConfig.TxEncoder(), 
-			signer_extraction.NewDefaultAdapter(), 
-			base.NoopComparator(), 
+			base.DefaultTxPriority(),
+			s.encodingConfig.TxConfig.TxEncoder(),
+			signer_extraction.NewDefaultAdapter(),
+			base.NoopComparator(),
 			3,
 		)
 
@@ -282,9 +282,9 @@ func (s *BaseTestSuite) TestSelect() {
 
 	s.Run("should be able to select a single transaction", func() {
 		mempool := base.NewMempool[string](
-			base.DefaultTxPriority(), 
-			s.encodingConfig.TxConfig.TxEncoder(), 
-			signer_extraction.NewDefaultAdapter(), 
+			base.DefaultTxPriority(),
+			s.encodingConfig.TxConfig.TxEncoder(),
+			signer_extraction.NewDefaultAdapter(),
 			base.NoopComparator(),
 			3,
 		)

--- a/lanes/base/mempool_test.go
+++ b/lanes/base/mempool_test.go
@@ -9,8 +9,10 @@ import (
 	testutils "github.com/skip-mev/block-sdk/testutils"
 )
 
-func (s *BaseTestSuite) TestCompareTxPriority() {
-	lane := s.initLane(math.LegacyOneDec(), nil)
+func (s *BaseTestSuite) TestCompareTxPriorityPriorityNonce() {
+	sea := signer_extraction.NewDefaultAdapter()
+	txp := base.DefaultTxPriority()
+	priorityNonceComparator := base.PriorityNonceComparator(sea, txp)
 
 	s.Run("should return -1 when signers are the same but the first tx has a higher sequence", func() {
 		tx1, err := testutils.CreateRandomTx(
@@ -35,7 +37,7 @@ func (s *BaseTestSuite) TestCompareTxPriority() {
 		)
 		s.Require().NoError(err)
 
-		cmp, err := lane.Compare(sdk.Context{}, tx1, tx2)
+		cmp, err := priorityNonceComparator(sdk.Context{}, tx1, tx2)
 		s.Require().NoError(err)
 		s.Require().Equal(-1, cmp)
 	})
@@ -63,7 +65,7 @@ func (s *BaseTestSuite) TestCompareTxPriority() {
 		)
 		s.Require().NoError(err)
 
-		cmp, err := lane.Compare(sdk.Context{}, tx1, tx2)
+		cmp, err := priorityNonceComparator(sdk.Context{}, tx1, tx2)
 		s.Require().NoError(err)
 		s.Require().Equal(1, cmp)
 	})
@@ -91,7 +93,7 @@ func (s *BaseTestSuite) TestCompareTxPriority() {
 		)
 		s.Require().NoError(err)
 
-		_, err = lane.Compare(sdk.Context{}, tx1, tx2)
+		_, err = priorityNonceComparator(sdk.Context{}, tx1, tx2)
 		s.Require().Error(err)
 	})
 
@@ -118,14 +120,20 @@ func (s *BaseTestSuite) TestCompareTxPriority() {
 		)
 		s.Require().NoError(err)
 
-		cmp, err := lane.Compare(sdk.Context{}, tx1, tx2)
+		cmp, err := priorityNonceComparator(sdk.Context{}, tx1, tx2)
 		s.Require().NoError(err)
 		s.Require().Equal(1, cmp)
 	})
 }
 
 func (s *BaseTestSuite) TestInsert() {
-	mempool := base.NewMempool[string](base.DefaultTxPriority(), s.encodingConfig.TxConfig.TxEncoder(), signer_extraction.NewDefaultAdapter(), 3)
+	mempool := base.NewMempool[string](
+		base.DefaultTxPriority(), 
+		s.encodingConfig.TxConfig.TxEncoder(), 
+		signer_extraction.NewDefaultAdapter(), 
+		base.NoopComparator(), 
+		3,
+	)
 
 	s.Run("should be able to insert a transaction", func() {
 		tx, err := testutils.CreateRandomTx(
@@ -180,7 +188,13 @@ func (s *BaseTestSuite) TestInsert() {
 }
 
 func (s *BaseTestSuite) TestRemove() {
-	mempool := base.NewMempool[string](base.DefaultTxPriority(), s.encodingConfig.TxConfig.TxEncoder(), signer_extraction.NewDefaultAdapter(), 3)
+	mempool := base.NewMempool[string](
+		base.DefaultTxPriority(), 
+		s.encodingConfig.TxConfig.TxEncoder(), 
+		signer_extraction.NewDefaultAdapter(), 
+		base.NoopComparator(),
+		3,
+	)
 
 	s.Run("should be able to remove a transaction", func() {
 		tx, err := testutils.CreateRandomTx(
@@ -220,7 +234,13 @@ func (s *BaseTestSuite) TestRemove() {
 
 func (s *BaseTestSuite) TestSelect() {
 	s.Run("should be able to select transactions in the correct order", func() {
-		mempool := base.NewMempool[string](base.DefaultTxPriority(), s.encodingConfig.TxConfig.TxEncoder(), signer_extraction.NewDefaultAdapter(), 3)
+		mempool := base.NewMempool[string](
+			base.DefaultTxPriority(), 
+			s.encodingConfig.TxConfig.TxEncoder(), 
+			signer_extraction.NewDefaultAdapter(), 
+			base.NoopComparator(), 
+			3,
+		)
 
 		tx1, err := testutils.CreateRandomTx(
 			s.encodingConfig.TxConfig,
@@ -261,7 +281,13 @@ func (s *BaseTestSuite) TestSelect() {
 	})
 
 	s.Run("should be able to select a single transaction", func() {
-		mempool := base.NewMempool[string](base.DefaultTxPriority(), s.encodingConfig.TxConfig.TxEncoder(), signer_extraction.NewDefaultAdapter(), 3)
+		mempool := base.NewMempool[string](
+			base.DefaultTxPriority(), 
+			s.encodingConfig.TxConfig.TxEncoder(), 
+			signer_extraction.NewDefaultAdapter(), 
+			base.NoopComparator(),
+			3,
+		)
 
 		tx1, err := testutils.CreateRandomTx(
 			s.encodingConfig.TxConfig,

--- a/lanes/free/lane.go
+++ b/lanes/free/lane.go
@@ -20,7 +20,7 @@ func NewFreeLane[C comparable](
 ) *base.BaseLane {
 	options := []base.LaneOption{
 		base.WithMatchHandler(matchFn),
-		base.WithMempoolConfigs[C](cfg, txPriority),
+		base.WithMempoolConfigs[C](cfg, txPriority, base.NoopComparator()),
 	}
 
 	lane, err := base.NewBaseLane(

--- a/lanes/mev/lane.go
+++ b/lanes/mev/lane.go
@@ -34,7 +34,7 @@ func NewMEVLane(
 ) *MEVLane {
 	options := []base.LaneOption{
 		base.WithMatchHandler(matchHandler),
-		base.WithMempoolConfigs[string](cfg, TxPriority(factory)),
+		base.WithMempoolConfigs[string](cfg, TxPriority(factory), base.NoopComparator()),
 	}
 
 	baseLane, err := base.NewBaseLane(

--- a/testutils/utils.go
+++ b/testutils/utils.go
@@ -1,6 +1,7 @@
 package testutils
 
 import (
+	"fmt"
 	"math/rand"
 	"testing"
 
@@ -161,6 +162,49 @@ func CreateRandomTx(txCfg client.TxConfig, account Account, nonce, numberMsgs, t
 		Sequence: nonce,
 	}
 	if err := txBuilder.SetSignatures(sigV2); err != nil {
+		return nil, err
+	}
+
+	txBuilder.SetTimeoutHeight(timeout)
+
+	txBuilder.SetFeeAmount(fees)
+
+	txBuilder.SetGasLimit(gasLimit)
+
+	return txBuilder.GetTx(), nil
+}
+
+func CreateRandomTxMultipleSigners(txCfg client.TxConfig, accounts []Account, nonce, numberMsgs, timeout uint64, gasLimit uint64, fees ...sdk.Coin) (authsigning.Tx, error) {
+	if len(accounts) == 0 {
+		return nil, fmt.Errorf("no accounts provided")
+	}
+
+	msgs := make([]sdk.Msg, numberMsgs)
+	for i := 0; i < int(numberMsgs); i++ {
+		msgs[i] = &banktypes.MsgSend{
+			FromAddress: accounts[0].Address.String(),
+			ToAddress:   accounts[0].Address.String(),
+		}
+	}
+
+	txBuilder := txCfg.NewTxBuilder()
+	if err := txBuilder.SetMsgs(msgs...); err != nil {
+		return nil, err
+	}
+
+	sigs := make([]signing.SignatureV2, len(accounts))
+	for i, acc := range accounts {
+		sigs[i] = signing.SignatureV2{
+			PubKey: acc.PrivKey.PubKey(),
+			Data: &signing.SingleSignatureData{
+				SignMode:  signing.SignMode_SIGN_MODE_DIRECT,
+				Signature: nil,
+			},
+			Sequence: nonce,
+		}
+	}
+
+	if err := txBuilder.SetSignatures(sigs...); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
## In This PR
- @davidterpay adds a test-case for Prepare / ProcessProposal w/ txs that have multiple fee-denoms
- To address issues identified from the above tc
     - I change the default behavior of a lane to ignore the `ProcessProposal` order comparison check
     - I introduce a `comparator` into the `Mempool` to make this logic configurable
     - I change the default `Mempool` to use a `NoopComparator` which always returns that tx order is valid