### PR TITLE
refactor(abci/checktx): remove duplication and simplify the code

### DIFF
--- a/abci/checktx/check_tx_test.go
+++ b/abci/checktx/check_tx_test.go
@@ -172,7 +172,7 @@ func (s *CheckTxTestSuite) TestMempoolParityCheckTx() {
 			nil,
 		)
 
-		res, err := handler.CheckTx()(&cometabci.RequestCheckTx{Tx: []byte("invalid-tx")})
+		res, err := handler.CheckTx()(&cometabci.RequestCheckTx{Type: cometabci.CheckTxType_Recheck, Tx: []byte("invalid-tx")})
 		s.Require().NoError(err)
 
 		s.Require().Equal(uint32(1), res.Code)

--- a/abci/checktx/mempool_parity_check_tx.go
+++ b/abci/checktx/mempool_parity_check_tx.go
@@ -40,17 +40,19 @@ func NewMempoolParityCheckTx(logger log.Logger, mempl block.Mempool, txDecoder s
 // in the app-side mempool on ReCheckTx.
 func (m MempoolParityCheckTx) CheckTx() CheckTx {
 	return func(req *cmtabci.RequestCheckTx) (*cmtabci.ResponseCheckTx, error) {
-		// decode tx
+		// This method check the tx only if the CheckTxType mode is ReCheck. Otherwise, we continue to the next checkHandler.
+		if req.Type != cmtabci.CheckTxType_Recheck {
+			return m.checkTxHandler(req)
+		}
+
 		tx, err := m.txDecoder(req.Tx)
 		if err != nil {
 			return errorResponse(fmt.Errorf("failed to decode tx: %w", err)), nil
 		}
 
-		isReCheck := req.Type == cmtabci.CheckTxType_Recheck
-
-		// if the mode is ReCheck and the app's mempool does not contain the given tx, we fail
-		// immediately, to purge the tx from the comet mempool.
-		if isReCheck && !m.mempl.Contains(tx) {
+		// In the ReCheck mode the app's mempool should contain the given tx.
+		// If not, we fail immediately, to purge the tx from the comet mempool.
+		if !m.mempl.Contains(tx) {
 			m.logger.Debug(
 				"tx from comet mempool not found in app-side mempool",
 				"tx", tx,
@@ -61,19 +63,15 @@ func (m MempoolParityCheckTx) CheckTx() CheckTx {
 		// run the checkTxHandler
 		res, checkTxError := m.checkTxHandler(req)
 
-		// if re-check fails for a transaction, we'll need to explicitly purge the tx from
-		// the app-side mempool
-		if isInvalidCheckTxExecution(res, checkTxError) && isReCheck {
-			// check if the tx exists first
-			if m.mempl.Contains(tx) {
-				// remove the tx
-				if err = m.mempl.Remove(tx); err != nil {
-					m.logger.Debug(
-						"failed to remove tx from app-side mempool when purging for re-check failure",
-						"removal-err", err,
-						"check-tx-err", checkTxError,
-					)
-				}
+		// if re-check fails for a transaction, we'll need to explicitly purge the tx from the app-side mempool
+		if isInvalidCheckTxExecution(res, checkTxError) {
+			// remove the tx
+			if err = m.mempl.Remove(tx); err != nil {
+				m.logger.Debug(
+					"failed to remove tx from app-side mempool when purging for re-check failure",
+					"removal-err", err,
+					"check-tx-err", checkTxError,
+				)
 			}
 		}
 


### PR DESCRIPTION
This PR removes duplication and simplifies the code:

1. 
```go
sdkerrors.ResponseCheckTxWithEvents( fmt.Errorf("<some error message>: %w", err), 0, 0, nil, false, )
```
is replaced with 

```go
errorResponse(err).
```

2. The CheckTx method of MempoolParityCheckTx only check transactions if the check Tx type is 'ReCheck'. If the check type is different, it immediately proceeds to the next checkTxHandler. This approach avoids redundant checks and logic, such as decoding the transaction, which is duplicated across all checkTxHandlers. It also eliminates the need to call isInvalidCheckTxExecution.

3. By checking the mode of the check transaction at the beginning of the CheckTx method, additional checks in the if statements can be avoided. For example:

```go
isReCheck := req.Type == cmtabci.CheckTxType_Recheck

// if the mode is ReCheck and the app's mempool does not contain the given tx, we fail
// immediately, to purge the tx from the comet mempool.
if isReCheck && !m.mempl.Contains(tx) {
    ...
}
```
Now is simpliefied and looks like:

```go
if !m.mempl.Contains(tx) {
    ...
}
```

And
```go
if isInvalidCheckTxExecution(res, checkTxError) && isReCheck {
  ...
}
```  
is now:

```go
if isInvalidCheckTxExecution(res, checkTxError) {
   ...
}   
```

4. Removed the check for whether the mempool contains the transaction before deleting it because the Remove method already performs this check, making it redundant.

5. Adjust method and function comments to aligns with Go best practices. 