### PR TITLE
perf: Remove double hashing

### DIFF
--- a/abci/checktx/mempool_parity_check_tx.go
+++ b/abci/checktx/mempool_parity_check_tx.go
@@ -55,10 +55,11 @@ func (m MempoolParityCheckTx) CheckTx() CheckTx {
 		}
 
 		isReCheck := req.Type == cmtabci.CheckTxType_Recheck
+		txInMempool := m.mempl.Contains(tx)
 
 		// if the mode is ReCheck and the app's mempool does not contain the given tx, we fail
 		// immediately, to purge the tx from the comet mempool.
-		if isReCheck && !m.mempl.Contains(tx) {
+		if isReCheck && !txInMempool {
 			m.logger.Debug(
 				"tx from comet mempool not found in app-side mempool",
 				"tx", tx,
@@ -80,7 +81,7 @@ func (m MempoolParityCheckTx) CheckTx() CheckTx {
 		// the app-side mempool
 		if isInvalidCheckTxExecution(res, checkTxError) && isReCheck {
 			// check if the tx exists first
-			if m.mempl.Contains(tx) {
+			if txInMempool {
 				// remove the tx
 				if err := m.mempl.Remove(tx); err != nil {
 					m.logger.Debug(


### PR DESCRIPTION
Remove two hashes here.

All CheckTx calls are synchronous from Tendermint, so theres no race condition concerns I missed. If there were race condition concerns, then we should do a single hash and then do a quick check for if things are contained in cache.