### PR TITLE
chore: Pin goreleaser to v1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,5 +27,6 @@ jobs:
         uses: goreleaser/goreleaser-action@v5
         with:
           args: release --clean
+          version: "~> v1"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Builds broke because of v2 of goreleaser. Copying the Slinky pin commit https://github.com/skip-mev/slinky/commit/e7bf7a2d7c30024a6e083a09795f1179fc06b7a0