### PR TITLE
fix: patch CheckTx handler for MEVCheckTxHandler

### DIFF
--- a/abci/checktx/mev_check_tx.go
+++ b/abci/checktx/mev_check_tx.go
@@ -102,9 +102,8 @@ func (handler *MEVCheckTxHandler) CheckTx() CheckTx {
 					"err", rec,
 				)
 
-				err = fmt.Errorf("panic in check tx handler: %s", rec)
 				resp = sdkerrors.ResponseCheckTxWithEvents(
-					err,
+					fmt.Errorf("panic in check tx handler: %s", rec),
 					0,
 					0,
 					nil,


### PR DESCRIPTION
These changes fix an issue with the `CheckTx` function in the `MEVCheckTxHandler` struct. In the recovery handler for the function the error log was being assigned to `err` before being returned as an actual error value rather than a request response as expected. 

This was causing the `CListMempool` handler for `CheckTx` in CometBFT to panic [here](https://github.com/cometbft/cometbft/blob/main/mempool/clist_mempool.go#L396), which when called from `Reactor` via a gossiped transaction would cause the entire node to panic.

This produced the following panic as an example:

```bash
Jan 28 21:09:12 osmosisd[1890649]: 9:09PM ERR panic in check tx handler err="Block (unix) time must never be empty or negative " module=server
Jan 28 21:09:12 osmosisd[1890649]: panic: CheckTx request for tx [3 239 186 250 113 194 109 146 101 179 30 66 199 179 85 138 170 18 218 138 135 64 46 171 203 233 51 254 186 47 85 186] failed: panic in check tx handler: Block (unix) time must never be empty or negative
Jan 28 21:09:12 osmosisd[1890649]: goroutine 400 [running]:
Jan 28 21:09:12 osmosisd[1890649]: github.com/cometbft/cometbft/mempool.(*CListMempool).CheckTx(0xc001da6a80, {0xc132950000, 0x5e5, 0x5e5}, 0x0, {0x0?, {0xc24dcbf1d0?, 0x0?}})
```